### PR TITLE
Fix: Pin production dependencies to stable commit hashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if(NOT BUILD_DOCS_ONLY)
     FetchContent_Declare(
         tinyobjloader
         GIT_REPOSITORY https://github.com/tinyobjloader/tinyobjloader.git
-        GIT_TAG release
+        GIT_TAG 45636bdcef1a4fec140346b90c0b50bf0bc3e23b
     )
     # tinyobjloader may call add_sanitizers() even when the helper module is unavailable.
     if(NOT COMMAND add_sanitizers)
@@ -68,7 +68,7 @@ if(NOT BUILD_DOCS_ONLY)
 
     FetchContent_Declare(stb
         GIT_REPOSITORY https://github.com/nothings/stb.git
-        GIT_TAG master
+        GIT_TAG 2c980bb59875b0d32144a71867fbdebb2f77cd20
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
     )
@@ -96,7 +96,7 @@ if(NOT BUILD_DOCS_ONLY)
 
     FetchContent_Declare(openal
         GIT_REPOSITORY https://github.com/kcat/openal-soft.git
-        GIT_TAG master
+        GIT_TAG 3f94a50884e2ae4963092fead7d299127e97e5d5
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
     )
@@ -105,7 +105,7 @@ if(NOT BUILD_DOCS_ONLY)
     FetchContent_Declare(
         dr_libs
         GIT_REPOSITORY https://github.com/mackron/dr_libs.git
-        GIT_TAG master
+        GIT_TAG b55a0d9a30b91ad8901f89ecf05f76a33186c185
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
     )


### PR DESCRIPTION
Closes #31

Pins the four production dependencies (tinyobjloader, stb, openal-soft, dr_libs) to exact commit hashes instead of moving branch tags so builds are reproducible.