### PR TITLE
Fix: Replace global include_directories with target-scoped includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,11 +115,6 @@ if(NOT BUILD_DOCS_ONLY)
     set(HEADERS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/headers")
     set(SOURCES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/sources")
 
-    # Add the headers directories
-    include_directories(
-        ${HEADERS_DIR}
-    )
-
     # Add the source files
     file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS
         "${SOURCES_DIR}/*.cpp"


### PR DESCRIPTION
Closes #33

Removes the global include_directories from the root CMakeLists.txt. The library already declares its headers directory through target_include_directories, and the test target uses target-scoped includes, so the global declaration only served to pollute third-party targets.