### PR TITLE
Fix: Enable tests in build CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,13 @@ jobs:
           cmake
           -B ${{ github.workspace }}/build
           -S ${{ github.workspace }}
+          -DBUILD_TESTING=ON
 
       - name: Build
         run: >
           cmake
           --build ${{ github.workspace }}/build
+
+      - name: Run tests
+        working-directory: ${{ github.workspace }}/build
+        run: ctest --output-on-failure


### PR DESCRIPTION
Closes #36

The build workflow now configures with -DBUILD_TESTING=ON and runs ctest --output-on-failure, so regressions are caught on all three OS runners.