### PR TITLE
Feat: Add CMake install and export rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,51 @@ if(NOT BUILD_DOCS_ONLY)
             $<BUILD_INTERFACE:${stb_SOURCE_DIR}>
             $<BUILD_INTERFACE:${dr_libs_SOURCE_DIR}>
     )
+
+    # 10. Install & export rules
+    # Allow downstream projects to consume the library via find_package().
+
+    include(GNUInstallDirs)
+    include(CMakePackageConfigHelpers)
+
+    set(UTILITY_INSTALL_CMAKEDIR
+        "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+    install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+
+    install(DIRECTORY ${HEADERS_DIR}/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        FILES_MATCHING PATTERN "*.hpp"
+    )
+
+    install(EXPORT ${PROJECT_NAME}Targets
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION ${UTILITY_INSTALL_CMAKEDIR}
+    )
+
+    configure_package_config_file(
+        cmake/${PROJECT_NAME}Config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+        INSTALL_DESTINATION ${UTILITY_INSTALL_CMAKEDIR}
+    )
+
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion
+    )
+
+    install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+        DESTINATION ${UTILITY_INSTALL_CMAKEDIR}
+    )
 endif()
 
 # 08. Documentations

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ if(NOT BUILD_DOCS_ONLY)
     set(FMT_OS_X_VERSION 10.15 CACHE STRING "" FORCE)
     FetchContent_MakeAvailable(fmt)
 
-    # Disable building examples, tests, and utilities for OpenAL Soft
+    # Disable building examples, tests, and utilities for OpenAL Soft.
     set(ALSOFT_EXAMPLES OFF CACHE BOOL "" FORCE)
     set(ALSOFT_TESTS OFF CACHE BOOL "" FORCE)
     set(ALSOFT_UTILS OFF CACHE BOOL "" FORCE)
@@ -135,13 +135,16 @@ if(NOT BUILD_DOCS_ONLY)
     )
 
     # 07. Link dependencies
+    # PUBLIC deps are referenced by public headers and must be exported;
+    # PRIVATE deps are implementation-only and need not appear in the export set.
     target_link_libraries(${PROJECT_NAME}
         PUBLIC
             tinyobjloader
             glm
             freetype
-            fmt::fmt
             OpenAL::OpenAL
+        PRIVATE
+            fmt::fmt
     )
 
     if(WIN32)
@@ -169,13 +172,29 @@ if(NOT BUILD_DOCS_ONLY)
     set(UTILITY_INSTALL_CMAKEDIR
         "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
-    install(TARGETS ${PROJECT_NAME}
+    # Install the PUBLIC dependency targets into the same export set so the
+    # exported utility target's PUBLIC link dependencies resolve for consumers.
+    install(TARGETS ${PROJECT_NAME} glm glm-header-only tinyobjloader freetype fmt
         EXPORT ${PROJECT_NAME}Targets
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
+
+    # OpenAL declares its public headers as a FILE_SET, which must be installed
+    # when the target is exported. Handle it in a dedicated install command.
+    if(TARGET OpenAL)
+        install(TARGETS OpenAL
+            EXPORT ${PROJECT_NAME}Targets
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+            FILE_SET public_headers
+                DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        )
+    endif()
 
     install(DIRECTORY ${HEADERS_DIR}/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/cmake/utilityConfig.cmake.in
+++ b/cmake/utilityConfig.cmake.in
@@ -5,6 +5,8 @@ include(CMakeFindDependencyMacro)
 find_dependency(glm)
 find_dependency(freetype)
 find_dependency(OpenAL)
+find_dependency(tinyobjloader)
+find_dependency(fmt)
 
 if(NOT TARGET @PROJECT_NAME@::@PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/cmake/utilityConfig.cmake.in
+++ b/cmake/utilityConfig.cmake.in
@@ -1,0 +1,13 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(glm)
+find_dependency(freetype)
+find_dependency(OpenAL)
+
+if(NOT TARGET @PROJECT_NAME@::@PROJECT_NAME@)
+    include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+endif()
+
+check_required_components(@PROJECT_NAME@)


### PR DESCRIPTION
Closes #35

Adds install/export rules and a package config template so the library can be consumed via find_package(utility). The target is exported as utility::utility.