### PR TITLE
Feat: Add tests for previously uncovered modules

### DIFF
--- a/tests/headers/event/test_event.hpp
+++ b/tests/headers/event/test_event.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+namespace tests::utility::event
+{
+	class TestEvent: public ::testing::Test
+	{
+		protected:
+		void SetUp(void) override
+		{
+		}
+		void TearDown(void) override
+		{
+		}
+	};
+}	 // namespace tests::utility::event

--- a/tests/headers/graphic/test_code_points.hpp
+++ b/tests/headers/graphic/test_code_points.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+namespace tests::utility::graphic
+{
+	class TestCodePoints: public ::testing::Test
+	{
+		protected:
+		void SetUp(void) override
+		{
+		}
+		void TearDown(void) override
+		{
+		}
+	};
+}	 // namespace tests::utility::graphic

--- a/tests/headers/test_cache.hpp
+++ b/tests/headers/test_cache.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+namespace tests::utility
+{
+	class TestCache: public ::testing::Test
+	{
+		protected:
+		void SetUp(void) override
+		{
+		}
+		void TearDown(void) override
+		{
+		}
+	};
+}	 // namespace tests::utility

--- a/tests/headers/test_file.hpp
+++ b/tests/headers/test_file.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+namespace tests::utility
+{
+	class TestFile: public ::testing::Test
+	{
+		protected:
+		void SetUp(void) override
+		{
+		}
+		void TearDown(void) override
+		{
+		}
+	};
+}	 // namespace tests::utility

--- a/tests/sources/event/test_event.cpp
+++ b/tests/sources/event/test_event.cpp
@@ -1,0 +1,77 @@
+#include "event/test_event.hpp"
+
+#include "utility/event/mouse_motion_event.hpp"
+#include "utility/event/mouse_button_event.hpp"
+#include "utility/event/quit_event.hpp"
+#include "utility/math/vector.hpp"
+
+using namespace utility::event;
+using namespace utility::math;
+using namespace tests::utility::event;
+
+TEST_F(TestEvent, MouseMotionDefaults)
+{
+	MouseMotionEvent event;
+	Vector2F expected{ 0, 0 };
+	EXPECT_EQ(event.getPosition(), expected);
+}
+
+TEST_F(TestEvent, MouseMotionSetAndGet)
+{
+	MouseMotionEvent event;
+	Vector2F pos{ 12.5f, 7.0f };
+	event.setPosition(pos);
+	EXPECT_EQ(event.getPosition(), pos);
+}
+
+TEST_F(TestEvent, MouseMotionFactoryCreatesTypedEvent)
+{
+	MouseMotionEvent::Factory factory;
+	auto event = factory.createTyped();
+	Vector2F zero{ 0, 0 };
+	ASSERT_NE(event, nullptr);
+	EXPECT_EQ(event->getPosition(), zero);
+}
+
+TEST_F(TestEvent, MouseMotionFactoryCreatesBaseEvent)
+{
+	MouseMotionEvent::Factory factory;
+	auto event = factory.create();
+	ASSERT_NE(event, nullptr);
+	EXPECT_NE(std::dynamic_pointer_cast<MouseMotionEvent>(event), nullptr);
+}
+
+TEST_F(TestEvent, MouseButtonDefaults)
+{
+	MouseButtonEvent event;
+	EXPECT_EQ(event.getButton(), MouseButtonEvent::Button::Unknown);
+	EXPECT_FALSE(event.isButtonPressed());
+}
+
+TEST_F(TestEvent, MouseButtonSetters)
+{
+	MouseButtonEvent event;
+	Vector2F pos{ 1.0f, 2.0f };
+	event.setButton(MouseButtonEvent::Button::Right)
+		.setPressed(true)
+		.setPosition(pos);
+	EXPECT_EQ(event.getButton(), MouseButtonEvent::Button::Right);
+	EXPECT_TRUE(event.isButtonPressed());
+	EXPECT_EQ(event.getPosition(), pos);
+}
+
+TEST_F(TestEvent, MouseButtonFactoryCreatesTypedEvent)
+{
+	MouseButtonEvent::Factory factory;
+	auto event = factory.createTyped();
+	ASSERT_NE(event, nullptr);
+	EXPECT_EQ(event->getButton(), MouseButtonEvent::Button::Unknown);
+}
+
+TEST_F(TestEvent, QuitEventFactoryCreatesBaseEvent)
+{
+	QuitEvent::Factory factory;
+	auto event = factory.create();
+	ASSERT_NE(event, nullptr);
+	EXPECT_NE(std::dynamic_pointer_cast<QuitEvent>(event), nullptr);
+}

--- a/tests/sources/graphic/test_code_points.cpp
+++ b/tests/sources/graphic/test_code_points.cpp
@@ -1,0 +1,47 @@
+#include "graphic/test_code_points.hpp"
+
+#include "utility/graphic/text/code_points.hpp"
+
+using namespace utility::graphic;
+using namespace tests::utility::graphic;
+
+TEST_F(TestCodePoints, ParseAndLookup)
+{
+	CodePoints codes("space 0x20\nA 0x41\neuro 20ac\n");
+	EXPECT_EQ(codes.getCode("space"), 0x20);
+	EXPECT_EQ(codes.getCode("A"), 0x41);
+	EXPECT_EQ(codes.getCode("euro"), 0x20AC);
+}
+
+TEST_F(TestCodePoints, MissingNameReturnsZero)
+{
+	CodePoints codes("A 41\n");
+	EXPECT_EQ(codes.getCode("missing"), 0);
+}
+
+TEST_F(TestCodePoints, EmptyContentYieldsNoCodes)
+{
+	CodePoints codes("");
+	EXPECT_EQ(codes.getCode("A"), 0);
+}
+
+TEST_F(TestCodePoints, ToUtf8Ascii)
+{
+	EXPECT_EQ(CodePoints::toUtf8(0x41), std::string("A"));
+}
+
+TEST_F(TestCodePoints, ToUtf8TwoByte)
+{
+	EXPECT_EQ(CodePoints::toUtf8(0xE9), std::string("\xC3\xA9"));
+}
+
+TEST_F(TestCodePoints, ToUtf8ThreeByte)
+{
+	EXPECT_EQ(CodePoints::toUtf8(0x20AC), std::string("\xE2\x82\xAC"));
+}
+
+TEST_F(TestCodePoints, ToUtf8FourByte)
+{
+	EXPECT_EQ(CodePoints::toUtf8(0x1F600),
+			  std::string("\xF0\x9F\x98\x80"));
+}

--- a/tests/sources/test_cache.cpp
+++ b/tests/sources/test_cache.cpp
@@ -1,0 +1,101 @@
+#include "test_cache.hpp"
+
+#include "utility/cache.hpp"
+
+using namespace utility;
+
+namespace tests::utility
+{
+
+	TEST_F(TestCache, StartsEmpty)
+	{
+		Cache<int, int> cache;
+		EXPECT_TRUE(cache.empty());
+		EXPECT_EQ(cache.size(), 0);
+	}
+
+	TEST_F(TestCache, PutAndGet)
+	{
+		Cache<std::string, int> cache;
+		cache.put("answer", 42);
+		EXPECT_TRUE(cache.contains("answer"));
+		EXPECT_EQ(cache.get("answer"), std::optional<int>(42));
+	}
+
+	TEST_F(TestCache, GetMissingReturnsNullopt)
+	{
+		Cache<int, int> cache;
+		EXPECT_EQ(cache.get(1), std::nullopt);
+		EXPECT_FALSE(cache.contains(1));
+	}
+
+	TEST_F(TestCache, PutOverwrites)
+	{
+		Cache<int, int> cache;
+		cache.put(1, 10);
+		cache.put(1, 20);
+		EXPECT_EQ(cache.get(1), std::optional<int>(20));
+	}
+
+	TEST_F(TestCache, PutMove)
+	{
+		Cache<int, std::string> cache;
+		std::string value = "hello";
+		cache.put(1, std::move(value));
+		EXPECT_EQ(cache.get(1), std::optional<std::string>("hello"));
+	}
+
+	TEST_F(TestCache, EmplaceReturnsEntry)
+	{
+		Cache<int, std::string> cache;
+		std::string &entry = cache.emplace(1, "alpha");
+		EXPECT_EQ(entry, "alpha");
+		EXPECT_TRUE(cache.contains(1));
+	}
+
+	TEST_F(TestCache, EraseExistingReturnsTrue)
+	{
+		Cache<int, int> cache;
+		cache.put(1, 1);
+		EXPECT_TRUE(cache.erase(1));
+		EXPECT_FALSE(cache.contains(1));
+	}
+
+	TEST_F(TestCache, EraseMissingReturnsFalse)
+	{
+		Cache<int, int> cache;
+		EXPECT_FALSE(cache.erase(42));
+	}
+
+	TEST_F(TestCache, EraseIfRemovesMatching)
+	{
+		Cache<int, int> cache;
+		cache.put(1, 5);
+		cache.put(2, 15);
+		cache.put(3, 25);
+		cache.erase_if([](int, int value) { return value > 10; });
+		EXPECT_TRUE(cache.contains(1));
+		EXPECT_FALSE(cache.contains(2));
+		EXPECT_FALSE(cache.contains(3));
+	}
+
+	TEST_F(TestCache, ApplyMutatesEntries)
+	{
+		Cache<int, int> cache;
+		cache.put(1, 1);
+		cache.put(2, 2);
+		cache.apply([](int, int &value) { value *= 2; });
+		EXPECT_EQ(cache.get(1), std::optional<int>(2));
+		EXPECT_EQ(cache.get(2), std::optional<int>(4));
+	}
+
+	TEST_F(TestCache, ClearEmptiesCache)
+	{
+		Cache<int, int> cache;
+		cache.put(1, 1);
+		cache.put(2, 2);
+		cache.clear();
+		EXPECT_TRUE(cache.empty());
+	}
+
+}	 // namespace tests::utility

--- a/tests/sources/test_file.cpp
+++ b/tests/sources/test_file.cpp
@@ -1,0 +1,109 @@
+#include "test_file.hpp"
+
+#include "utility/system_io/file.hpp"
+
+using namespace utility;
+
+namespace tests::utility
+{
+
+	TEST_F(TestFile, InitialState)
+	{
+		File file("/tmp/asset.bin", "hello");
+		EXPECT_EQ(file.path(), "/tmp/asset.bin");
+		EXPECT_EQ(file.content(), "hello");
+		EXPECT_EQ(file.size(), 5);
+		EXPECT_EQ(file.tell(), 0);
+	}
+
+	TEST_F(TestFile, ReadIntoBuffer)
+	{
+		File file("/tmp/asset.bin", "abcdef");
+		char buffer[6] = {};
+		size_t n = file.read(buffer, 1, 6);
+		EXPECT_EQ(n, 6);
+		EXPECT_EQ(std::string(buffer, 6), "abcdef");
+		EXPECT_EQ(file.tell(), 6);
+	}
+
+	TEST_F(TestFile, ReadPastEndClamps)
+	{
+		File file("/tmp/asset.bin", "abc");
+		char buffer[10] = {};
+		size_t n = file.read(buffer, 1, 10);
+		EXPECT_EQ(n, 3);
+		EXPECT_EQ(file.tell(), 3);
+	}
+
+	TEST_F(TestFile, ReadIntoString)
+	{
+		File file("/tmp/asset.bin", "xyz");
+		std::string out;
+		size_t n = file.read(out, 1, 2);
+		EXPECT_EQ(n, 2);
+		EXPECT_EQ(out, "xy");
+	}
+
+	TEST_F(TestFile, WriteInsertsAtPosition)
+	{
+		File file("/tmp/asset.bin", "ab");
+		size_t n = file.write("cd", 1, 2);
+		EXPECT_EQ(n, 2);
+		EXPECT_EQ(file.content(), "cdab");
+		EXPECT_EQ(file.tell(), 2);
+	}
+
+	TEST_F(TestFile, WriteAppendsAtEnd)
+	{
+		File file("/tmp/asset.bin", "ab");
+		file.seek(0, File::Seek::END);
+		size_t n = file.write("cd", 1, 2);
+		EXPECT_EQ(n, 2);
+		EXPECT_EQ(file.content(), "abcd");
+		EXPECT_EQ(file.tell(), 4);
+	}
+
+	TEST_F(TestFile, SeekModes)
+	{
+		File file("/tmp/asset.bin", "abcdef");
+		EXPECT_EQ(file.seek(2, File::Seek::SET), 0);
+		EXPECT_EQ(file.tell(), 2);
+		EXPECT_EQ(file.seek(1, File::Seek::CUR), 0);
+		EXPECT_EQ(file.tell(), 3);
+		EXPECT_EQ(file.seek(-1, File::Seek::END), 0);
+		EXPECT_EQ(file.tell(), 5);
+	}
+
+	TEST_F(TestFile, SeekNegativeRejected)
+	{
+		File file("/tmp/asset.bin", "abcdef");
+		EXPECT_EQ(file.seek(-5, File::Seek::SET), -1);
+		EXPECT_EQ(file.tell(), 0);
+	}
+
+	TEST_F(TestFile, SeekUnknownRejected)
+	{
+		File file("/tmp/asset.bin", "abcdef");
+		EXPECT_EQ(file.seek(0, static_cast<File::Seek>(99)), -1);
+	}
+
+	TEST_F(TestFile, ClearResets)
+	{
+		File file("/tmp/asset.bin", "abcdef");
+		file.seek(3, File::Seek::SET);
+		file.clear();
+		EXPECT_TRUE(file.content().empty());
+		EXPECT_EQ(file.size(), 0);
+		EXPECT_EQ(file.tell(), 0);
+	}
+
+	TEST_F(TestFile, RemoveErasesFromPosition)
+	{
+		File file("/tmp/asset.bin", "abcdef");
+		file.seek(2, File::Seek::SET);
+		size_t n = file.remove(2);
+		EXPECT_EQ(n, 2);
+		EXPECT_EQ(file.content(), "abef");
+	}
+
+}	 // namespace tests::utility


### PR DESCRIPTION
Closes #37

Adds tests for Cache, File, CodePoints, and the event module factories, all of which previously had no coverage. Each covers the public API contract including edge cases.