### PR TITLE
Docs: Expand README and module documentation for adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,66 @@ Utility is the shared support library used by the other libraries in this
 workspace. It collects common math, graphics, event, logging, asset, and helper
 types so the higher layers can stay focused on UI and rendering.
 
+It targets modern desktop and extended-reality (XR) applications and is written
+in C++20.
+
 ## What It Provides
 
-- Math primitives and helpers.
-- Graphics data types such as vertices, colors, poses, and meshes.
-- Event models for mouse, keyboard, text input, and XR hand interactions.
-- Logging and singleton helpers.
-- Asset manager abstractions for desktop and Android.
+| Module | Headers | Purpose |
+| ------ | ------- | ------- |
+| `utility::math` | `headers/utility/math/` | Vectors, matrices, quaternions, trigonometric and integer helpers |
+| `utility::graphic` | `headers/utility/graphic/` | Colors, poses, vertices, meshes, materials, shaders, text and font helpers |
+| `utility::event` | `headers/utility/event/` | Mouse, keyboard, text-input, and XR hand event models |
+| `utility::system_io` | `headers/utility/system_io/` | Desktop and Android asset / file loading helpers |
+| `utility::logging` | `headers/utility/logging/` | Logger interfaces and implementations |
+| `utility::sound` | `headers/utility/sound/` | Audio buffers, sources, and decoders |
 
-## Build Notes
+## Requirements
 
-Utility is a C++20 library built with CMake and fetched dependencies such as
-GLM, tinyobjloader, stb, and freetype.
+- CMake 3.10 or newer
+- A C++20 compiler
+- Doxygen and Graphviz (only if you build the documentation)
+
+Dependencies are fetched automatically at configure time using
+`FetchContent`: GLM, tinyobjloader, stb, FreeType, fmt, OpenAL Soft, and
+dr_libs.
+
+## Building
+
+```sh
+cmake -S . -B build -DBUILD_TESTING=ON
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+To install the library so it can be consumed via `find_package`:
+
+```sh
+cmake --install build
+```
+
+The build is reproducible: all fetched dependencies are pinned to immutable
+commit hashes or tags, never to moving branch names.
+
+## Using in a downstream project
+
+Once installed, link against the `utility::utility` target:
+
+```cmake
+find_package(utility CONFIG REQUIRED)
+
+target_link_libraries(my_app PRIVATE utility::utility)
+```
+
+## Testing
+
+Tests use GoogleTest and live under `tests/`. Enable them with
+`-DBUILD_TESTING=ON`. They cover the math, graphic, event, system_io, logging,
+and helper modules, including edge cases and invalid-input paths.
 
 ## Documentation
 
 - [Architecture](docs/ARCHITECTURE.md)
-- [How Utility Works](docs/HOW_GUILLAUME_WORKS.md)
+- [Modules](docs/MODULES.md)
 - [Technical Choices](docs/TECHNICAL_CHOICES.md)
+- [How Utility Works](docs/HOW_GUILLAUME_WORKS.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,9 +10,44 @@ the rest of the workspace can reuse them without pulling in higher-level code.
   textures, vertices, and text helpers.
 - `utility::event` contains platform and input event models.
 - `utility::system_io` contains desktop and Android asset loading helpers.
+- `utility::sound` contains audio buffers, sources, and decoders.
 - `utility::logging` contains logger interfaces and implementations.
 
-## Design Goal
+## Layer Ownership
 
-Keep the library small, reusable, and dependency-light so the engine, UI, and
-application layers can share the same data model.
+Utility sits at the bottom of the dependency stack. Higher layers (engine, UI,
+application) depend on Utility; Utility must never depend on them.
+
+```
+ Application
+     |
+   UI / Rendering
+     |
+   Engine
+     |
+ Utility  <- shared foundation
+```
+
+Because every layer shares the same data model, care must be taken to keep
+module boundaries clean:
+
+- `utility::math` has no dependencies on other utility modules.
+- `utility::graphic` may depend on `utility::math` and `utility::system_io`.
+- `utility::system_io` should not depend on graphic or logging types.
+- `utility::event` depends only on `utility::math`.
+
+## Dependency Flow
+
+Dependencies are fetched with CMake `FetchContent` and pinned to immutable
+tags or commit hashes for reproducible builds. See
+[TECHNICAL_CHOICES.md](TECHNICAL_CHOICES.md) for the full list.
+
+## Build and Package
+
+- The project builds a static/shared `utility` target and exports
+  `utility::utility` for downstream `find_package` consumers.
+- Tests are optional (`BUILD_TESTING=ON`) and use GoogleTest.
+- Documentation is optional (`BUILD_DOCS=ON`) and built with Doxygen.
+
+See [MODULES.md](MODULES.md) for per-module invariants, coordinate and
+thread-safety conventions.

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1,0 +1,106 @@
+# Utility Modules
+
+This document describes each module's responsibilities, invariants, and
+conventions. It is intended for adopters who need to integrate the library
+into their own code.
+
+## Conventions
+
+### Namespaces and layout
+
+Public headers live under `headers/utility/<module>/` and are included as
+`utility/<module>/<header>.hpp`. Implementations live under `sources/` in the
+same module structure.
+
+### Coordinate systems
+
+- Math primitives are engine-agnostic and use right-handed, Y-up conventions.
+- `utility::graphic` types that are UI-facing (for example ray intersection
+  helpers) may adopt a Y-down convention. Check the individual header for the
+  intended convention before assuming a default.
+- Angles are consistently expressed in **radians** throughout the library.
+  Conversion helpers are available in `utility/math/trigonometric.hpp`.
+
+### Numeric conventions
+
+- Math components are floating-point (`float`/`double`). Matrices and vectors
+  store components in **column-major** order for columns/rows of `2..4`, and
+  `Matrix`/`Vector` provide both direct component access and GLM interop.
+- Comparisons of floating-point types use the operators provided by the
+  underlying GLM types; if you need tolerant comparisons, prefer an epsilon
+  helper over `==`.
+
+### Thread-safety
+
+Thread-safety is opt-in per type. Unless a header explicitly documents
+thread-safety, instances are **not** safe to share across threads without
+external synchronization. Specifically:
+
+- `utility::Cache` is declared thread-safe and is intended for concurrent
+  access. (If you observe otherwise, report it: it must be synchronized.)
+- `utility::logging` is currently not thread-safe; route logs from a single
+  thread or add your own mutex.
+- `utility::sound::AudioManager` uses a runtime control flag that must be
+  treated as single-threaded access.
+
+### Backend assumptions
+
+- Graphics and font code assume a Vulkan-like depth range and Y-flip unless a
+  header notes otherwise.
+- Text rendering depends on FreeType; the public font APIs do not expose
+  FreeType types directly, but they internally assume FreeType behavior.
+- Audio depends on OpenAL Soft. Decoders are registered through
+  `utility::sound::DecoderRegistry`.
+
+## Modules
+
+### `utility::math`
+
+Vectors, matrices, quaternions, and scalar helpers backed by GLM.
+
+- Types: `Vector`, `Matrix`, `Quaternion`, and free functions for perspective,
+  look-at, rotation, and integer/trigonometric helpers.
+- Invariants: square matrices default to a documented construction; component
+  counts are fixed at compile time and validated at construction.
+- Use: construct with braced lists of exactly the required number of
+  components.
+
+### `utility::graphic`
+
+Rendering-friendly data types.
+
+- Types: `Color`, `Pose`, `Position`, `Scale`, `Orientation`, `Vertex`,
+  `Mesh`, `Material`, `Shader`, `Texture`, `View`, `Ray`, and text/font types
+  (`Font`, `FontSized`, `CodePoints`, `Text`).
+- Assets such as materials, models, shaders, and textures are usually loaded
+  through `utility::RessourceProvider` rather than constructed directly.
+- OBJ models are imported via tinyobjloader; images via stb.
+
+### `utility::event`
+
+Event models for input and XR interactions.
+
+- Types: `Event`, `MouseMotionEvent`, `MouseButtonEvent`, keyboard and text
+  input events, and XR hand events.
+- Each concrete event exposes a `Factory` that produces either a base `Event`
+  or a strongly typed instance.
+
+### `utility::system_io`
+
+Asset and file helpers for desktop and Android.
+
+- `File` is an in-memory read/write buffer with a seek cursor. It stores
+  content as a byte string; prefer it for in-memory asset manipulation.
+
+### `utility::logging`
+
+Logger interfaces and implementations.
+
+- Provides a leveled logger. Levels control whether messages are emitted.
+
+### `utility::sound`
+
+Audio buffers, sources, and decoders.
+
+- Types: `AudioBuffer`, `AudioSource`, `AudioManager`, and decoders for WAV
+  and MP3 registered through `DecoderRegistry`.

--- a/docs/TECHNICAL_CHOICES.md
+++ b/docs/TECHNICAL_CHOICES.md
@@ -6,18 +6,35 @@ Utility is written in C++20 for consistency with the rest of the workspace.
 
 ## Dependencies
 
+All dependencies are fetched at configure time with CMake `FetchContent` and
+pinned to immutable tags or commit hashes so builds are reproducible.
+
 - GLM for math primitives.
 - tinyobjloader for mesh import support.
 - stb for lightweight image and text asset support.
-- freetype for font and glyph handling.
+- FreeType for font and glyph handling.
+- fmt for formatting.
+- OpenAL Soft for audio output.
+- dr_libs for audio decoding.
 - DbgHelp on Windows for symbol and stack-related helpers.
 
 ## Build Model
 
 Utility is built with CMake and exposes its headers as a reusable include
-surface for the other libraries.
+surface for the other libraries. It also ships install and export rules so it
+can be consumed through `find_package(utility)`.
+
+## Backend Assumptions
+
+- Rendering and text code assume a Vulkan-like depth range and Y-flip unless a
+  given header documents otherwise. UI-facing geometry may use a Y-down
+  convention; verify per header.
+- Text rendering internally depends on FreeType behavior.
+- Audio depends on OpenAL Soft; codecs are resolved through the decoder
+  registry.
 
 ## Design Choice
 
 The library centralizes common support code so higher layers do not each grow
-their own versions of the same helpers.
+their own versions of the same helpers, while keeping module boundaries (and
+their dependency rules) explicit.


### PR DESCRIPTION
Closes #40

- Expanded README with build/test/install instructions, a module table, and downstream find_package usage
- Added docs/MODULES.md documenting invariants, coordinate systems, numeric conventions, thread-safety, and backend assumptions
- Expanded ARCHITECTURE.md with layer ownership and dependency-flow rules
- Expanded TECHNICAL_CHOICES.md with reproducibility and backend assumptions