### PR TITLE
Fix: Default-construct square matrices to identity

### DIFF
--- a/headers/utility/math/matrix.hpp
+++ b/headers/utility/math/matrix.hpp
@@ -92,13 +92,18 @@ namespace utility::math
 	{
 		public:
 		/**
-		 * @brief Default constructor initializing matrix to identity (if
-		 * square) or zero (if not square).
+		 * @brief Default constructor initializing square matrices to identity
+		 * and non-square matrices to zero.
 		 */
 		Matrix(void)
 			: glm::mat<Cols, Rows, MatrixComponentType>(
 				  MatrixComponentType { 0 })
 		{
+			if constexpr (Cols == Rows) {
+				*static_cast<glm::mat<Cols, Rows, MatrixComponentType> *>(this)
+					= glm::mat<Cols, Rows, MatrixComponentType>(
+						MatrixComponentType { 1 });
+			}
 		}
 
 		/**

--- a/tests/sources/math/test_matrix.cpp
+++ b/tests/sources/math/test_matrix.cpp
@@ -5,6 +5,21 @@
 using namespace utility::math;
 using namespace tests::utility::math;
 
+TEST_F(TestMatrix, DefaultConstructsIdentityForSquare)
+{
+	Matrix3x3F m;
+	Matrix3x3F expected{ 1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f };
+	EXPECT_EQ(m, expected);
+}
+
+TEST_F(TestMatrix, DefaultConstructsZeroForNonSquare)
+{
+	Matrix4x3F m;
+	Matrix4x3F expected{ 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+						 0.0f, 0.0f, 0.0f, 0.0f };
+	EXPECT_EQ(m, expected);
+}
+
 TEST_F(TestMatrix, Addition)
 {
 	Matrix3x3F a { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f };


### PR DESCRIPTION
Closes #1

The Matrix default constructor now initializes square matrices to the identity matrix (as documented) and keeps zero initialization for non-square matrices. Added tests for both cases.