### PR TITLE
Fix: Support non-square matrix multiplication

### DIFF
--- a/headers/utility/math/matrix.hpp
+++ b/headers/utility/math/matrix.hpp
@@ -277,24 +277,35 @@ namespace utility::math
 
 		/**
 		 * @brief Matrix multiplication.
+		 * @tparam RhsCols Number of columns of the RHS matrix.
+		 * @tparam RhsRows Number of rows of the RHS matrix.
 		 * @param rhs The matrix to multiply with.
-		 * @return The resulting matrix.
+		 * @return The resulting matrix with shape (Rows, RhsCols).
+		 * @note Requires this matrix's column count to equal the RHS row count
+		 * (Cols == RhsRows).
 		 */
-		Matrix operator*(const Matrix &rhs) const
+		template<std::size_t RhsCols, std::size_t RhsRows>
+			requires (Cols == RhsRows)
+		Matrix<MatrixComponentType, RhsCols, Rows>
+			operator*(const Matrix<MatrixComponentType, RhsCols, RhsRows> &rhs)
+				const
 		{
-			return Matrix(
-				static_cast<const glm::mat<Cols, Rows, MatrixComponentType> &>(
-					*this)
-				* static_cast<
-					const glm::mat<Cols, Rows, MatrixComponentType> &>(rhs));
+			using LhsGlm =
+				glm::mat<Cols, Rows, MatrixComponentType>;
+			using RhsGlm =
+				glm::mat<RhsCols, RhsRows, MatrixComponentType>;
+			return Matrix<MatrixComponentType, RhsCols, Rows>(
+				static_cast<const LhsGlm &>(*this)
+				* static_cast<const RhsGlm &>(rhs));
 		}
 
 		/**
-		 * @brief Matrix multiplication assignment.
+		 * @brief Matrix multiplication assignment (square matrices only).
 		 * @param rhs The matrix to multiply with.
 		 * @return A reference to this matrix after multiplication.
 		 */
 		Matrix &operator*=(const Matrix &rhs)
+			requires (Cols == Rows)
 		{
 			*static_cast<glm::mat<Cols, Rows, MatrixComponentType> *>(this) =
 				static_cast<const glm::mat<Cols, Rows, MatrixComponentType> &>(

--- a/tests/sources/math/test_matrix.cpp
+++ b/tests/sources/math/test_matrix.cpp
@@ -69,3 +69,13 @@ TEST_F(TestMatrix, Equality)
 	EXPECT_TRUE(a == b);
 	EXPECT_FALSE(a != b);
 }
+
+TEST_F(TestMatrix, NonSquareMultiplication)
+{
+	Matrix2x3F lhs { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
+	Matrix3x2F rhs { 7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f };
+	auto result = lhs * rhs;
+	EXPECT_NEAR(result[0][0], 27.0f, 1e-5f);
+	EXPECT_NEAR(result[1][1], 68.0f, 1e-5f);
+	EXPECT_NEAR(result[2][2], 117.0f, 1e-5f);
+}


### PR DESCRIPTION
Closes #2

operator* is now templated on the RHS dimensions with a requires clause (Cols == RhsRows), returning the correct result shape (Rows x RhsCols). operator*= is constrained to square matrices where in-place multiplication is well-defined. Added a non-square multiplication test.