### PR TITLE
Feat: Add equalsEpsilon helpers for math types

### DIFF
--- a/headers/utility/math/matrix.hpp
+++ b/headers/utility/math/matrix.hpp
@@ -306,6 +306,9 @@ namespace utility::math
 
 		/**
 		 * @brief Equality comparison.
+		 *
+		 * Uses exact component-wise equality. For floating-point types prefer
+		 * equalsEpsilon to tolerate rounding error.
 		 * @param rhs The matrix to compare with.
 		 * @return True if the matrices are equal, false otherwise.
 		 */
@@ -315,6 +318,29 @@ namespace utility::math
 					   const glm::mat<Cols, Rows, MatrixComponentType> &>(*this)
 				== static_cast<
 					   const glm::mat<Cols, Rows, MatrixComponentType> &>(rhs);
+		}
+
+		/**
+		 * @brief Approximate equality using an epsilon threshold.
+		 *
+		 * Returns true if each component is within @p epsilon of its counterpart
+		 * in @p rhs.
+		 * @param rhs The matrix to compare with.
+		 * @param epsilon The maximum allowed difference per component.
+		 * @return True if the matrices are equal within epsilon.
+		 */
+		bool equalsEpsilon(const Matrix &rhs,
+						   MatrixComponentType epsilon =
+							   MatrixComponentType { 1e-5 }) const
+		{
+			for (std::size_t col = 0; col < Cols; ++col) {
+				for (std::size_t row = 0; row < Rows; ++row) {
+					if (std::abs((*this)[col][row] - rhs[col][row]) > epsilon) {
+						return false;
+					}
+				}
+			}
+			return true;
 		}
 
 		/**

--- a/headers/utility/math/quaternion.hpp
+++ b/headers/utility/math/quaternion.hpp
@@ -227,6 +227,9 @@ namespace utility::math
 
 		/**
 		 * @brief Equality comparison.
+		 *
+		 * Uses exact component-wise equality. For floating-point types prefer
+		 * equalsEpsilon to tolerate rounding error.
 		 * @param rhs The quaternion to compare with.
 		 * @return True if the quaternions are equal, false otherwise.
 		 */
@@ -234,6 +237,25 @@ namespace utility::math
 		{
 			return static_cast<const glm::qua<QuaternionComponentType> &>(*this)
 				== static_cast<const glm::qua<QuaternionComponentType> &>(rhs);
+		}
+
+		/**
+		 * @brief Approximate equality using an epsilon threshold.
+		 *
+		 * Returns true if each component is within @p epsilon of its counterpart
+		 * in @p rhs.
+		 * @param rhs The quaternion to compare with.
+		 * @param epsilon The maximum allowed difference per component.
+		 * @return True if the quaternions are equal within epsilon.
+		 */
+		bool equalsEpsilon(const Quaternion &rhs,
+						   QuaternionComponentType epsilon =
+							   QuaternionComponentType { 1e-5 }) const
+		{
+			return std::abs(this->x - rhs.x) <= epsilon
+				&& std::abs(this->y - rhs.y) <= epsilon
+				&& std::abs(this->z - rhs.z) <= epsilon
+				&& std::abs(this->w - rhs.w) <= epsilon;
 		}
 
 		/**

--- a/headers/utility/math/vector.hpp
+++ b/headers/utility/math/vector.hpp
@@ -330,6 +330,9 @@ namespace utility::math
 
 		/**
 		 * @brief Equality comparison.
+		 *
+		 * Uses exact component-wise equality. For floating-point types prefer
+		 * equalsEpsilon to tolerate rounding error.
 		 * @param rhs The vector to compare with.
 		 * @return True if the vectors are equal, false otherwise.
 		 */
@@ -341,6 +344,27 @@ namespace utility::math
 				== static_cast<
 					   const glm::vec<VectorDimension, VectorComponentType> &>(
 					   rhs);
+		}
+
+		/**
+		 * @brief Approximate equality using an epsilon threshold.
+		 *
+		 * Returns true if each component is within @p epsilon of its counterpart
+		 * in @p rhs.
+		 * @param rhs The vector to compare with.
+		 * @param epsilon The maximum allowed difference per component.
+		 * @return True if the vectors are equal within epsilon.
+		 */
+		bool equalsEpsilon(const Vector &rhs,
+						   VectorComponentType epsilon =
+							   VectorComponentType { 1e-5 }) const
+		{
+			for (std::size_t i = 0; i < VectorDimension; ++i) {
+				if (std::abs((*this)[i] - rhs[i]) > epsilon) {
+					return false;
+				}
+			}
+			return true;
 		}
 
 		/**

--- a/tests/sources/math/test_matrix.cpp
+++ b/tests/sources/math/test_matrix.cpp
@@ -69,3 +69,24 @@ TEST_F(TestMatrix, Equality)
 	EXPECT_TRUE(a == b);
 	EXPECT_FALSE(a != b);
 }
+
+TEST_F(TestMatrix, ExactEqualityRejectsRounding)
+{
+	Matrix3x3F a { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f };
+	Matrix3x3F b { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.000001f };
+	EXPECT_FALSE(a == b);
+}
+
+TEST_F(TestMatrix, EpsilonEqualityAcceptsTinyDifference)
+{
+	Matrix3x3F a { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f };
+	Matrix3x3F b { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.000001f };
+	EXPECT_TRUE(a.equalsEpsilon(b));
+}
+
+TEST_F(TestMatrix, EpsilonEqualityRejectsLargeDifference)
+{
+	Matrix3x3F a { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f };
+	Matrix3x3F b { 2.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f };
+	EXPECT_FALSE(a.equalsEpsilon(b));
+}

--- a/tests/sources/math/test_quaternion.cpp
+++ b/tests/sources/math/test_quaternion.cpp
@@ -54,3 +54,24 @@ TEST_F(TestQuaternion, Equality)
 	EXPECT_TRUE(a == b);
 	EXPECT_FALSE(a != b);
 }
+
+TEST_F(TestQuaternion, ExactEqualityRejectsRounding)
+{
+	QuaternionF a { 1.0f, 2.0f, 3.0f, 4.0f };
+	QuaternionF b { 1.0f, 2.0f, 3.0f, 4.000001f };
+	EXPECT_FALSE(a == b);
+}
+
+TEST_F(TestQuaternion, EpsilonEqualityAcceptsTinyDifference)
+{
+	QuaternionF a { 1.0f, 2.0f, 3.0f, 4.0f };
+	QuaternionF b { 1.0f, 2.0f, 3.0f, 4.000001f };
+	EXPECT_TRUE(a.equalsEpsilon(b));
+}
+
+TEST_F(TestQuaternion, EpsilonEqualityRejectsLargeDifference)
+{
+	QuaternionF a { 1.0f, 2.0f, 3.0f, 4.0f };
+	QuaternionF b { 1.5f, 2.0f, 3.0f, 4.0f };
+	EXPECT_FALSE(a.equalsEpsilon(b));
+}

--- a/tests/sources/math/test_vector.cpp
+++ b/tests/sources/math/test_vector.cpp
@@ -79,3 +79,24 @@ TEST_F(TestVector, Equality)
 	EXPECT_TRUE(a == b);
 	EXPECT_FALSE(a != b);
 }
+
+TEST_F(TestVector, ExactEqualityRejectsRounding)
+{
+	Vector3F a { 1.0f, 2.0f, 3.0f };
+	Vector3F b { 1.0f + 1e-6f, 2.0f, 3.0f };
+	EXPECT_FALSE(a == b);
+}
+
+TEST_F(TestVector, EpsilonEqualityAcceptsTinyDifference)
+{
+	Vector3F a { 1.0f, 2.0f, 3.0f };
+	Vector3F b { 1.0f + 1e-6f, 2.0f, 3.0f };
+	EXPECT_TRUE(a.equalsEpsilon(b));
+}
+
+TEST_F(TestVector, EpsilonEqualityRejectsLargeDifference)
+{
+	Vector3F a { 1.0f, 2.0f, 3.0f };
+	Vector3F b { 1.1f, 2.0f, 3.0f };
+	EXPECT_FALSE(a.equalsEpsilon(b));
+}


### PR DESCRIPTION
Closes #3

Adds equalsEpsilon to Vector, Matrix, and Quaternion so callers can compare floating-point values tolerantly. operator== remains exact and is now documented as such. Added tests showing exact equality rejects tiny differences while equalsEpsilon accepts them.