### PR TITLE
Fix: Guard division by zero in Vector and Matrix

### DIFF
--- a/headers/utility/math/matrix.hpp
+++ b/headers/utility/math/matrix.hpp
@@ -254,9 +254,13 @@ namespace utility::math
 		 * @brief Scalar division.
 		 * @param scalar The scalar value to divide by.
 		 * @return The resulting matrix.
+		 * @throws std::invalid_argument if scalar is zero.
 		 */
 		Matrix operator/(MatrixComponentType scalar) const
 		{
+			if (scalar == MatrixComponentType { 0 }) {
+				throw std::invalid_argument("Matrix division by zero");
+			}
 			return Matrix(
 				static_cast<const glm::mat<Cols, Rows, MatrixComponentType> &>(
 					*this)
@@ -267,9 +271,13 @@ namespace utility::math
 		 * @brief Scalar division assignment.
 		 * @param scalar The scalar value to divide by.
 		 * @return A reference to this matrix after division.
+		 * @throws std::invalid_argument if scalar is zero.
 		 */
 		Matrix &operator/=(MatrixComponentType scalar)
 		{
+			if (scalar == MatrixComponentType { 0 }) {
+				throw std::invalid_argument("Matrix division by zero");
+			}
 			*static_cast<glm::mat<Cols, Rows, MatrixComponentType> *>(this) /=
 				scalar;
 			return *this;

--- a/headers/utility/math/vector.hpp
+++ b/headers/utility/math/vector.hpp
@@ -247,9 +247,13 @@ namespace utility::math
 		 * @brief Scalar division.
 		 * @param scalar The scalar value to divide by.
 		 * @return The resulting vector.
+		 * @throws std::invalid_argument if scalar is zero.
 		 */
 		Vector operator/(VectorComponentType scalar) const
 		{
+			if (scalar == VectorComponentType { 0 }) {
+				throw std::invalid_argument("Vector division by zero");
+			}
 			return Vector(
 				static_cast<const glm::vec<VectorDimension, VectorComponentType>
 								&>(*this)
@@ -260,9 +264,13 @@ namespace utility::math
 		 * @brief Scalar division assignment.
 		 * @param scalar The scalar value to divide by.
 		 * @return A reference to this vector after division.
+		 * @throws std::invalid_argument if scalar is zero.
 		 */
 		Vector &operator/=(VectorComponentType scalar)
 		{
+			if (scalar == VectorComponentType { 0 }) {
+				throw std::invalid_argument("Vector division by zero");
+			}
 			*static_cast<glm::vec<VectorDimension, VectorComponentType> *>(
 				this) /= scalar;
 			return *this;
@@ -302,9 +310,15 @@ namespace utility::math
 		 * @brief Element-wise division.
 		 * @param rhs The vector to divide by.
 		 * @return The resulting vector.
+		 * @throws std::invalid_argument if any component of rhs is zero.
 		 */
 		Vector operator/(const Vector &rhs) const
 		{
+			for (std::size_t i = 0; i < VectorDimension; ++i) {
+				if (rhs[i] == VectorComponentType { 0 }) {
+					throw std::invalid_argument("Vector division by zero");
+				}
+			}
 			return Vector(
 				static_cast<const glm::vec<VectorDimension, VectorComponentType>
 								&>(*this)
@@ -317,9 +331,15 @@ namespace utility::math
 		 * @brief Element-wise division assignment.
 		 * @param rhs The vector to divide by.
 		 * @return A reference to this vector after division.
+		 * @throws std::invalid_argument if any component of rhs is zero.
 		 */
 		Vector &operator/=(const Vector &rhs)
 		{
+			for (std::size_t i = 0; i < VectorDimension; ++i) {
+				if (rhs[i] == VectorComponentType { 0 }) {
+					throw std::invalid_argument("Vector division by zero");
+				}
+			}
 			*static_cast<glm::vec<VectorDimension, VectorComponentType> *>(
 				this) /=
 				static_cast<

--- a/tests/sources/math/test_matrix.cpp
+++ b/tests/sources/math/test_matrix.cpp
@@ -69,3 +69,10 @@ TEST_F(TestMatrix, Equality)
 	EXPECT_TRUE(a == b);
 	EXPECT_FALSE(a != b);
 }
+
+TEST_F(TestMatrix, ScalarDivisionByZeroThrows)
+{
+	Matrix3x3F a { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f };
+	EXPECT_THROW(a / 0.0f, std::invalid_argument);
+	EXPECT_THROW(a /= 0.0f, std::invalid_argument);
+}

--- a/tests/sources/math/test_vector.cpp
+++ b/tests/sources/math/test_vector.cpp
@@ -79,3 +79,18 @@ TEST_F(TestVector, Equality)
 	EXPECT_TRUE(a == b);
 	EXPECT_FALSE(a != b);
 }
+
+TEST_F(TestVector, ScalarDivisionByZeroThrows)
+{
+	Vector3F a { 1.0f, 2.0f, 3.0f };
+	EXPECT_THROW(a / 0.0f, std::invalid_argument);
+	EXPECT_THROW(a /= 0.0f, std::invalid_argument);
+}
+
+TEST_F(TestVector, ElementwiseDivisionByZeroThrows)
+{
+	Vector3F a { 1.0f, 2.0f, 3.0f };
+	Vector3F zero{ 0.0f, 0.0f, 0.0f };
+	EXPECT_THROW(a / zero, std::invalid_argument);
+	EXPECT_THROW(a /= zero, std::invalid_argument);
+}


### PR DESCRIPTION
Closes #4

All scalar and element-wise division operators in Vector and Matrix now throw std::invalid_argument on a zero denominator, preventing undefined behavior (integral) and silent inf/NaN (floating-point). Added tests.