### PR TITLE
Docs: Clarify Quaternion constructor argument order

### DIFF
--- a/headers/utility/math/quaternion.hpp
+++ b/headers/utility/math/quaternion.hpp
@@ -77,7 +77,13 @@ namespace utility::math
 		}
 
 		/**
-		 * @brief Construct from explicit components (x, y, z, w).
+		 * @brief Construct from explicit components in (x, y, z, w) order.
+		 *
+		 * Note: this library exposes the parameter order (x, y, z, w) with the
+		 * scalar component (w) last. This deliberately differs from GLM's
+		 * `glm::qua(w, x, y, z)` constructor, which places the scalar component
+		 * first. The arguments are remapped internally; pass (x, y, z, w).
+		 *
 		 * @param x X component.
 		 * @param y Y component.
 		 * @param z Z component.

--- a/tests/sources/math/test_quaternion.cpp
+++ b/tests/sources/math/test_quaternion.cpp
@@ -54,3 +54,13 @@ TEST_F(TestQuaternion, Equality)
 	EXPECT_TRUE(a == b);
 	EXPECT_FALSE(a != b);
 }
+
+TEST_F(TestQuaternion, ConstructorMapsXyzwComponents)
+{
+	// The public API takes (x, y, z, w); the scalar component is last.
+	QuaternionF q { 1.0f, 2.0f, 3.0f, 4.0f };
+	EXPECT_FLOAT_EQ(q.x, 1.0f);
+	EXPECT_FLOAT_EQ(q.y, 2.0f);
+	EXPECT_FLOAT_EQ(q.z, 3.0f);
+	EXPECT_FLOAT_EQ(q.w, 4.0f);
+}


### PR DESCRIPTION
Closes #5

The Quaternion constructor exposes (x, y, z, w) with the scalar last, remapping to GLM's (w, x, y, z) internally. Documented this convention explicitly and added a test verifying the component mapping.