### PR TITLE
Fix: Make GLM conversion constructors explicit

### DIFF
--- a/headers/utility/graphic/orientation.hpp
+++ b/headers/utility/graphic/orientation.hpp
@@ -173,12 +173,14 @@ namespace utility::graphic
 		utility::math::Vector<OrientationComponentType, 3>
 			getForward(void) const noexcept
 		{
-			return utility::math::Quaternion<OrientationComponentType>(
-					   this->x, this->y, this->z, this->w)
-				* utility::math::Vector<OrientationComponentType, 3> {
-					  OrientationComponentType(0), OrientationComponentType(0),
-					  OrientationComponentType(-1)
-				  };
+			return utility::math::Vector<OrientationComponentType, 3>(
+				utility::math::Quaternion<OrientationComponentType>(
+					this->x, this->y, this->z, this->w)
+					* utility::math::Vector<OrientationComponentType, 3> {
+						OrientationComponentType(0),
+						OrientationComponentType(0),
+						OrientationComponentType(-1)
+					});
 		}
 
 		/**
@@ -220,9 +222,10 @@ namespace utility::graphic
 			const utility::math::Vector<OrientationComponentType, 3> &local)
 			const noexcept
 		{
-			return utility::math::Quaternion<OrientationComponentType>(
-					   this->x, this->y, this->z, this->w)
-				* local;
+			return utility::math::Vector<OrientationComponentType, 3>(
+				utility::math::Quaternion<OrientationComponentType>(
+					this->x, this->y, this->z, this->w)
+				* local);
 		}
 
 		/**
@@ -273,9 +276,10 @@ namespace utility::graphic
 		 */
 		Orientation normalized(void) const noexcept
 		{
-			return Orientation(utility::math::normalize(
-				static_cast<const utility::math::Quaternion<
-					OrientationComponentType> &>(*this)));
+			return Orientation(utility::math::Quaternion<OrientationComponentType>(
+				utility::math::normalize(
+					static_cast<const utility::math::Quaternion<
+						OrientationComponentType> &>(*this))));
 		}
 
 		/**
@@ -284,9 +288,10 @@ namespace utility::graphic
 		 */
 		Orientation inversed(void) const noexcept
 		{
-			return Orientation(utility::math::inverse(
-				static_cast<const utility::math::Quaternion<
-					OrientationComponentType> &>(*this)));
+			return Orientation(utility::math::Quaternion<OrientationComponentType>(
+				utility::math::inverse(
+					static_cast<const utility::math::Quaternion<
+						OrientationComponentType> &>(*this))));
 		}
 
 		/**

--- a/headers/utility/graphic/view.hpp
+++ b/headers/utility/graphic/view.hpp
@@ -544,11 +544,13 @@ namespace utility::graphic
 			const auto orientation = _pose.getOrientation();
 			const auto position	   = _pose.getPosition();
 
-			utility::math::Matrix<ViewComponentType, 4, 4> view = glm::inverse(
-				glm::translate(glm::identity<glm::mat4>(),
-							   glm::vec3(position.x, position.y, position.z))
-				* glm::mat4_cast(glm::quat(orientation.w, orientation.x,
-										   orientation.y, orientation.z)));
+			utility::math::Matrix<ViewComponentType, 4, 4> view {
+				glm::inverse(
+					glm::translate(glm::identity<glm::mat4>(),
+								   glm::vec3(position.x, position.y, position.z))
+					* glm::mat4_cast(glm::quat(orientation.w, orientation.x,
+											   orientation.y, orientation.z)))
+			};
 
 			// GLM is column-major: view[col][row]
 			// view[0][0] = static_cast<ViewComponentType>(right[0]);

--- a/headers/utility/math/matrix.hpp
+++ b/headers/utility/math/matrix.hpp
@@ -135,7 +135,7 @@ namespace utility::math
 		 * @brief Construct from a GLM matrix.
 		 * @param value Source matrix.
 		 */
-		Matrix(const glm::mat<Cols, Rows, MatrixComponentType> &value)
+		explicit Matrix(const glm::mat<Cols, Rows, MatrixComponentType> &value)
 			: glm::mat<Cols, Rows, MatrixComponentType>(value)
 		{
 		}

--- a/headers/utility/math/quaternion.hpp
+++ b/headers/utility/math/quaternion.hpp
@@ -93,7 +93,7 @@ namespace utility::math
 		 * @brief Construct from a GLM quaternion.
 		 * @param q Source quaternion.
 		 */
-		Quaternion(const glm::qua<QuaternionComponentType> &q)
+		explicit Quaternion(const glm::qua<QuaternionComponentType> &q)
 			: glm::qua<QuaternionComponentType>(q)
 		{
 		}

--- a/headers/utility/math/vector.hpp
+++ b/headers/utility/math/vector.hpp
@@ -94,7 +94,7 @@ namespace utility::math
 		 * @brief Construct from a GLM vector.
 		 * @param v Source GLM vector.
 		 */
-		Vector(const glm::vec<VectorDimension, VectorComponentType> &v)
+		explicit Vector(const glm::vec<VectorDimension, VectorComponentType> &v)
 			: glm::vec<VectorDimension, VectorComponentType>(v)
 		{
 		}


### PR DESCRIPTION
Closes #6

Marks the GLM conversion constructors for Vector, Matrix, and Quaternion as explicit to prevent unintended implicit conversions, and updates the affected internal call sites in view.hpp and orientation.hpp to use direct initialization.