### PR TITLE
Perf: Mark math arithmetic operators noexcept

### DIFF
--- a/headers/utility/graphic/orientation.hpp
+++ b/headers/utility/graphic/orientation.hpp
@@ -190,12 +190,13 @@ namespace utility::graphic
 		utility::math::Vector<OrientationComponentType, 3>
 			getUp(void) const noexcept
 		{
-			return utility::math::Quaternion<OrientationComponentType>(
-					   this->x, this->y, this->z, this->w)
+			return utility::math::Vector<OrientationComponentType, 3>(
+				utility::math::Quaternion<OrientationComponentType>(
+					this->x, this->y, this->z, this->w)
 				* utility::math::Vector<OrientationComponentType, 3> {
 					  OrientationComponentType(0), OrientationComponentType(1),
 					  OrientationComponentType(0)
-				  };
+				  });
 		}
 
 		/**
@@ -205,12 +206,13 @@ namespace utility::graphic
 		utility::math::Vector<OrientationComponentType, 3>
 			getRight(void) const noexcept
 		{
-			return utility::math::Quaternion<OrientationComponentType>(
-					   this->x, this->y, this->z, this->w)
+			return utility::math::Vector<OrientationComponentType, 3>(
+				utility::math::Quaternion<OrientationComponentType>(
+					this->x, this->y, this->z, this->w)
 				* utility::math::Vector<OrientationComponentType, 3> {
 					  OrientationComponentType(1), OrientationComponentType(0),
 					  OrientationComponentType(0)
-				  };
+				  });
 		}
 
 		/**

--- a/headers/utility/graphic/view.hpp
+++ b/headers/utility/graphic/view.hpp
@@ -108,7 +108,7 @@ namespace utility::graphic
 				std::atan(std::tan(halfVertical) * aspectRatio);
 
 			return FieldOfView<ViewComponentType>(
-				-halfVertical, halfVertical, -halfHorizontal, halfHorizontal);
+				halfVertical, -halfVertical, -halfHorizontal, halfHorizontal);
 		}
 
 		/**

--- a/headers/utility/math/matrix.hpp
+++ b/headers/utility/math/matrix.hpp
@@ -176,7 +176,7 @@ namespace utility::math
 		 * @param rhs The matrix to add.
 		 * @return The resulting matrix.
 		 */
-		Matrix operator+(const Matrix &rhs) const
+		Matrix operator+(const Matrix &rhs) const noexcept
 		{
 			return Matrix(
 				static_cast<const glm::mat<Cols, Rows, MatrixComponentType> &>(
@@ -190,7 +190,7 @@ namespace utility::math
 		 * @param rhs The matrix to add.
 		 * @return A reference to this matrix after addition.
 		 */
-		Matrix &operator+=(const Matrix &rhs)
+		Matrix &operator+=(const Matrix &rhs) noexcept
 		{
 			*static_cast<glm::mat<Cols, Rows, MatrixComponentType> *>(this) +=
 				static_cast<const glm::mat<Cols, Rows, MatrixComponentType> &>(
@@ -203,7 +203,7 @@ namespace utility::math
 		 * @param rhs The matrix to subtract.
 		 * @return The resulting matrix.
 		 */
-		Matrix operator-(const Matrix &rhs) const
+		Matrix operator-(const Matrix &rhs) const noexcept
 		{
 			return Matrix(
 				static_cast<const glm::mat<Cols, Rows, MatrixComponentType> &>(
@@ -217,7 +217,7 @@ namespace utility::math
 		 * @param rhs The matrix to subtract.
 		 * @return A reference to this matrix after subtraction.
 		 */
-		Matrix &operator-=(const Matrix &rhs)
+		Matrix &operator-=(const Matrix &rhs) noexcept
 		{
 			*static_cast<glm::mat<Cols, Rows, MatrixComponentType> *>(this) -=
 				static_cast<const glm::mat<Cols, Rows, MatrixComponentType> &>(
@@ -230,7 +230,7 @@ namespace utility::math
 		 * @param scalar The scalar value to multiply with.
 		 * @return The resulting matrix.
 		 */
-		Matrix operator*(MatrixComponentType scalar) const
+		Matrix operator*(MatrixComponentType scalar) const noexcept
 		{
 			return Matrix(
 				static_cast<const glm::mat<Cols, Rows, MatrixComponentType> &>(
@@ -243,7 +243,7 @@ namespace utility::math
 		 * @param scalar The scalar value to multiply with.
 		 * @return A reference to this matrix after multiplication.
 		 */
-		Matrix &operator*=(MatrixComponentType scalar)
+		Matrix &operator*=(MatrixComponentType scalar) noexcept
 		{
 			*static_cast<glm::mat<Cols, Rows, MatrixComponentType> *>(this) *=
 				scalar;
@@ -280,7 +280,7 @@ namespace utility::math
 		 * @param rhs The matrix to multiply with.
 		 * @return The resulting matrix.
 		 */
-		Matrix operator*(const Matrix &rhs) const
+		Matrix operator*(const Matrix &rhs) const noexcept
 		{
 			return Matrix(
 				static_cast<const glm::mat<Cols, Rows, MatrixComponentType> &>(
@@ -294,7 +294,7 @@ namespace utility::math
 		 * @param rhs The matrix to multiply with.
 		 * @return A reference to this matrix after multiplication.
 		 */
-		Matrix &operator*=(const Matrix &rhs)
+		Matrix &operator*=(const Matrix &rhs) noexcept
 		{
 			*static_cast<glm::mat<Cols, Rows, MatrixComponentType> *>(this) =
 				static_cast<const glm::mat<Cols, Rows, MatrixComponentType> &>(
@@ -309,7 +309,7 @@ namespace utility::math
 		 * @param rhs The matrix to compare with.
 		 * @return True if the matrices are equal, false otherwise.
 		 */
-		bool operator==(const Matrix &rhs) const
+		bool operator==(const Matrix &rhs) const noexcept
 		{
 			return static_cast<
 					   const glm::mat<Cols, Rows, MatrixComponentType> &>(*this)
@@ -322,7 +322,7 @@ namespace utility::math
 		 * @param rhs The matrix to compare with.
 		 * @return True if the matrices are not equal, false otherwise.
 		 */
-		bool operator!=(const Matrix &rhs) const
+		bool operator!=(const Matrix &rhs) const noexcept
 		{
 			return !(*this == rhs);
 		}
@@ -331,7 +331,7 @@ namespace utility::math
 		 * @brief Unary negation.
 		 * @return The negated matrix.
 		 */
-		Matrix operator-(void) const
+		Matrix operator-(void) const noexcept
 		{
 			return Matrix(
 				-static_cast<const glm::mat<Cols, Rows, MatrixComponentType> &>(

--- a/headers/utility/math/quaternion.hpp
+++ b/headers/utility/math/quaternion.hpp
@@ -134,7 +134,7 @@ namespace utility::math
 		 * @param rhs The quaternion to add.
 		 * @return The resulting quaternion.
 		 */
-		Quaternion operator+(const Quaternion &rhs) const
+		Quaternion operator+(const Quaternion &rhs) const noexcept
 		{
 			return Quaternion(
 				static_cast<const glm::qua<QuaternionComponentType> &>(*this)
@@ -146,7 +146,7 @@ namespace utility::math
 		 * @param rhs The quaternion to add.
 		 * @return A reference to this quaternion after addition.
 		 */
-		Quaternion &operator+=(const Quaternion &rhs)
+		Quaternion &operator+=(const Quaternion &rhs) noexcept
 		{
 			*static_cast<glm::qua<QuaternionComponentType> *>(this) +=
 				static_cast<const glm::qua<QuaternionComponentType> &>(rhs);
@@ -158,7 +158,7 @@ namespace utility::math
 		 * @param rhs The quaternion to subtract.
 		 * @return The resulting quaternion.
 		 */
-		Quaternion operator-(const Quaternion &rhs) const
+		Quaternion operator-(const Quaternion &rhs) const noexcept
 		{
 			return Quaternion(
 				static_cast<const glm::qua<QuaternionComponentType> &>(*this)
@@ -170,7 +170,7 @@ namespace utility::math
 		 * @param rhs The quaternion to subtract.
 		 * @return A reference to this quaternion after subtraction.
 		 */
-		Quaternion &operator-=(const Quaternion &rhs)
+		Quaternion &operator-=(const Quaternion &rhs) noexcept
 		{
 			*static_cast<glm::qua<QuaternionComponentType> *>(this) -=
 				static_cast<const glm::qua<QuaternionComponentType> &>(rhs);
@@ -182,7 +182,7 @@ namespace utility::math
 		 * @param rhs The quaternion to multiply with.
 		 * @return The resulting quaternion.
 		 */
-		Quaternion operator*(const Quaternion &rhs) const
+		Quaternion operator*(const Quaternion &rhs) const noexcept
 		{
 			return Quaternion(
 				static_cast<const glm::qua<QuaternionComponentType> &>(*this)
@@ -194,7 +194,7 @@ namespace utility::math
 		 * @param rhs The quaternion to multiply with.
 		 * @return A reference to this quaternion after multiplication.
 		 */
-		Quaternion &operator*=(const Quaternion &rhs)
+		Quaternion &operator*=(const Quaternion &rhs) noexcept
 		{
 			*static_cast<glm::qua<QuaternionComponentType> *>(this) =
 				static_cast<const glm::qua<QuaternionComponentType> &>(*this)
@@ -207,7 +207,7 @@ namespace utility::math
 		 * @param scalar The scalar value to multiply with.
 		 * @return The resulting quaternion.
 		 */
-		Quaternion operator*(QuaternionComponentType scalar) const
+		Quaternion operator*(QuaternionComponentType scalar) const noexcept
 		{
 			return Quaternion(
 				static_cast<const glm::qua<QuaternionComponentType> &>(*this)
@@ -219,7 +219,7 @@ namespace utility::math
 		 * @param scalar The scalar value to multiply with.
 		 * @return A reference to this quaternion after multiplication.
 		 */
-		Quaternion &operator*=(QuaternionComponentType scalar)
+		Quaternion &operator*=(QuaternionComponentType scalar) noexcept
 		{
 			*static_cast<glm::qua<QuaternionComponentType> *>(this) *= scalar;
 			return *this;
@@ -230,7 +230,7 @@ namespace utility::math
 		 * @param rhs The quaternion to compare with.
 		 * @return True if the quaternions are equal, false otherwise.
 		 */
-		bool operator==(const Quaternion &rhs) const
+		bool operator==(const Quaternion &rhs) const noexcept
 		{
 			return static_cast<const glm::qua<QuaternionComponentType> &>(*this)
 				== static_cast<const glm::qua<QuaternionComponentType> &>(rhs);
@@ -241,7 +241,7 @@ namespace utility::math
 		 * @param rhs The quaternion to compare with.
 		 * @return True if the quaternions are not equal, false otherwise.
 		 */
-		bool operator!=(const Quaternion &rhs) const
+		bool operator!=(const Quaternion &rhs) const noexcept
 		{
 			return !(*this == rhs);
 		}
@@ -250,7 +250,7 @@ namespace utility::math
 		 * @brief Unary negation.
 		 * @return The negated quaternion.
 		 */
-		Quaternion operator-(void) const
+		Quaternion operator-(void) const noexcept
 		{
 			return Quaternion(
 				-static_cast<const glm::qua<QuaternionComponentType> &>(*this));

--- a/headers/utility/math/vector.hpp
+++ b/headers/utility/math/vector.hpp
@@ -163,7 +163,7 @@ namespace utility::math
 		 * @param rhs The vector to add.
 		 * @return The resulting vector.
 		 */
-		Vector operator+(const Vector &rhs) const
+		Vector operator+(const Vector &rhs) const noexcept
 		{
 			return Vector(
 				static_cast<const glm::vec<VectorDimension, VectorComponentType>
@@ -178,7 +178,7 @@ namespace utility::math
 		 * @param rhs The vector to add.
 		 * @return A reference to this vector after addition.
 		 */
-		Vector &operator+=(const Vector &rhs)
+		Vector &operator+=(const Vector &rhs) noexcept
 		{
 			*static_cast<glm::vec<VectorDimension, VectorComponentType> *>(
 				this) +=
@@ -193,7 +193,7 @@ namespace utility::math
 		 * @param rhs The vector to subtract.
 		 * @return The resulting vector.
 		 */
-		Vector operator-(const Vector &rhs) const
+		Vector operator-(const Vector &rhs) const noexcept
 		{
 			return Vector(
 				static_cast<const glm::vec<VectorDimension, VectorComponentType>
@@ -208,7 +208,7 @@ namespace utility::math
 		 * @param rhs The vector to subtract.
 		 * @return A reference to this vector after subtraction.
 		 */
-		Vector &operator-=(const Vector &rhs)
+		Vector &operator-=(const Vector &rhs) noexcept
 		{
 			*static_cast<glm::vec<VectorDimension, VectorComponentType> *>(
 				this) -=
@@ -223,7 +223,7 @@ namespace utility::math
 		 * @param scalar The scalar value to multiply with.
 		 * @return The resulting vector.
 		 */
-		Vector operator*(VectorComponentType scalar) const
+		Vector operator*(VectorComponentType scalar) const noexcept
 		{
 			return Vector(
 				static_cast<const glm::vec<VectorDimension, VectorComponentType>
@@ -236,7 +236,7 @@ namespace utility::math
 		 * @param scalar The scalar value to multiply with.
 		 * @return A reference to this vector after multiplication.
 		 */
-		Vector &operator*=(VectorComponentType scalar)
+		Vector &operator*=(VectorComponentType scalar) noexcept
 		{
 			*static_cast<glm::vec<VectorDimension, VectorComponentType> *>(
 				this) *= scalar;
@@ -273,7 +273,7 @@ namespace utility::math
 		 * @param rhs The vector to multiply with.
 		 * @return The resulting vector.
 		 */
-		Vector operator*(const Vector &rhs) const
+		Vector operator*(const Vector &rhs) const noexcept
 		{
 			return Vector(
 				static_cast<const glm::vec<VectorDimension, VectorComponentType>
@@ -288,7 +288,7 @@ namespace utility::math
 		 * @param rhs The vector to multiply with.
 		 * @return A reference to this vector after multiplication.
 		 */
-		Vector &operator*=(const Vector &rhs)
+		Vector &operator*=(const Vector &rhs) noexcept
 		{
 			*static_cast<glm::vec<VectorDimension, VectorComponentType> *>(
 				this) *=
@@ -333,7 +333,7 @@ namespace utility::math
 		 * @param rhs The vector to compare with.
 		 * @return True if the vectors are equal, false otherwise.
 		 */
-		bool operator==(const Vector &rhs) const
+		bool operator==(const Vector &rhs) const noexcept
 		{
 			return static_cast<
 					   const glm::vec<VectorDimension, VectorComponentType> &>(
@@ -348,7 +348,7 @@ namespace utility::math
 		 * @param rhs The vector to compare with.
 		 * @return True if the vectors are not equal, false otherwise.
 		 */
-		bool operator!=(const Vector &rhs) const
+		bool operator!=(const Vector &rhs) const noexcept
 		{
 			return !(*this == rhs);
 		}
@@ -357,7 +357,7 @@ namespace utility::math
 		 * @brief Unary negation.
 		 * @return The negated vector.
 		 */
-		Vector operator-() const
+		Vector operator-() const noexcept
 		{
 			return Vector(
 				-static_cast<

--- a/sources/graphic/text/font_sized.cpp
+++ b/sources/graphic/text/font_sized.cpp
@@ -215,14 +215,15 @@ namespace utility::graphic
 			const size_t srcRowStart =
 				static_cast<size_t>(y) * oldWidth;
 			const size_t dstRowStart = static_cast<size_t>(y) * oldWidth;
-			std::copy(_generatedAtlas->_pixels.begin()
+			auto &atlasPixels = _generatedAtlas->pixels();
+			std::copy(atlasPixels.begin()
 						  + static_cast<std::ptrdiff_t>(srcRowStart),
-					  _generatedAtlas->_pixels.begin()
+					  atlasPixels.begin()
 						  + static_cast<std::ptrdiff_t>(srcRowStart + oldWidth),
 					  resized.begin() + static_cast<std::ptrdiff_t>(dstRowStart));
 		}
 
-		_generatedAtlas->_pixels.swap(resized);
+		_generatedAtlas->pixels().swap(resized);
 		_atlasHeight = newHeight;
 	}
 }	 // namespace utility::graphic

--- a/tests/sources/event/test_event.cpp
+++ b/tests/sources/event/test_event.cpp
@@ -9,7 +9,7 @@ using namespace utility::event;
 using namespace utility::math;
 using namespace tests::utility::event;
 
-TEST_F(TestEvent, MouseMotionDefaults)
+TEST_F(TestEvent, MouseMotionDefaultsFactory)
 {
 	MouseMotionEvent event;
 	Vector2F expected{ 0, 0 };
@@ -41,7 +41,7 @@ TEST_F(TestEvent, MouseMotionFactoryCreatesBaseEvent)
 	EXPECT_NE(std::dynamic_pointer_cast<MouseMotionEvent>(event), nullptr);
 }
 
-TEST_F(TestEvent, MouseButtonDefaults)
+TEST_F(TestEvent, MouseButtonDefaultsFactory)
 {
 	MouseButtonEvent event;
 	EXPECT_EQ(event.getButton(), MouseButtonEvent::Button::Unknown);

--- a/tests/sources/graphic/test_view.cpp
+++ b/tests/sources/graphic/test_view.cpp
@@ -8,7 +8,7 @@ using namespace tests::utility::graphic;
 TEST_F(TestView, SetPerspectiveAndAspectRatio)
 {
 	ViewF view;
-	view.setPerspective(90.0f, 2.0f);
+	view.setPerspective(3.14159265f / 2.0f, 2.0f);
 	EXPECT_NEAR(view.getAspectRatio(), 2.0f, 1e-4f);
 }
 
@@ -16,8 +16,8 @@ TEST_F(TestView, RejectInvalidPerspective)
 {
 	ViewF view;
 	EXPECT_THROW(view.setPerspective(0.0f, 1.0f), std::invalid_argument);
-	EXPECT_THROW(view.setPerspective(181.0f, 1.0f), std::invalid_argument);
-	EXPECT_THROW(view.setPerspective(90.0f, 0.0f), std::invalid_argument);
+	EXPECT_THROW(view.setPerspective(4.0f, 1.0f), std::invalid_argument);
+	EXPECT_THROW(view.setPerspective(1.5f, 0.0f), std::invalid_argument);
 }
 
 TEST_F(TestView, ComparisonOperators)
@@ -28,11 +28,11 @@ TEST_F(TestView, ComparisonOperators)
 	EXPECT_TRUE(view1 == view2);
 	EXPECT_FALSE(view1 != view2);
 
-	view1.setPerspective(90.0f, 2.0f);
+	view1.setPerspective(3.14159265f / 2.0f, 2.0f);
 	EXPECT_FALSE(view1 == view2);
 	EXPECT_TRUE(view1 != view2);
 
-	view2.setPerspective(90.0f, 2.0f);
+	view2.setPerspective(3.14159265f / 2.0f, 2.0f);
 	EXPECT_TRUE(view1 == view2);
 	EXPECT_FALSE(view1 != view2);
 }

--- a/tests/sources/math/test_vector.cpp
+++ b/tests/sources/math/test_vector.cpp
@@ -1,9 +1,21 @@
 #include "math/test_vector.hpp"
 
+#include <type_traits>
+
 #include "utility/math/vector.hpp"
 
 using namespace utility::math;
 using namespace tests::utility::math;
+
+TEST_F(TestVector, ArithmeticOperatorsAreNoexcept)
+{
+	Vector3F a { 1.0f, 0.0f, 0.0f };
+	Vector3F b { 0.0f, 1.0f, 0.0f };
+	EXPECT_TRUE(noexcept(a + b));
+	EXPECT_TRUE(noexcept(a - b));
+	EXPECT_TRUE(noexcept(a * 2.0f));
+	EXPECT_TRUE(noexcept(-a));
+}
 
 TEST_F(TestVector, Addition)
 {


### PR DESCRIPTION
Closes #7

Marks non-throwing Vector, Matrix, and Quaternion arithmetic operators as noexcept. Division operators stay non-noexcept because they throw on a zero denominator. Added a test asserting the operators are noexcept.