### PR TITLE
Fix: Map unknown log levels to a high sentinel

### DIFF
--- a/sources/logging/logger.cpp
+++ b/sources/logging/logger.cpp
@@ -22,6 +22,7 @@
 
 #include <chrono>
 #include <iomanip>
+#include <limits>
 #include <sstream>
 
 #include "utility/logging/logger.hpp"
@@ -57,7 +58,9 @@ namespace utility::logging
 			case LogLevel::ERROR_LEVEL:
 				return 3;
 			default:
-				return -1;
+				// Return a high sentinel so an unknown/future level is treated
+				// as most severe and never silently dropped by the filter.
+				return std::numeric_limits<int>::max();
 		}
 	}
 

--- a/tests/sources/logging/test_logger.cpp
+++ b/tests/sources/logging/test_logger.cpp
@@ -141,6 +141,12 @@ TEST(LoggerTest, LogLevelValueOrder)
 			  Logger::levelValue(LogLevel::ERROR_LEVEL));
 }
 
+TEST(LoggerTest, UnknownLevelMapsToHighSentinel)
+{
+	auto unknown = static_cast<LogLevel>(999);
+	EXPECT_GT(Logger::levelValue(unknown), Logger::levelValue(LogLevel::ERROR_LEVEL));
+}
+
 TEST(LoggerTest, DefaultLoggerIsStandardLogger)
 {
 	static_assert(


### PR DESCRIPTION
Closes #21

Logger::levelValue now returns a high sentinel for unknown/future LogLevel values instead of -1, so new levels are treated as most severe and never silently dropped by the level filter.