### PR TITLE
Fix: Guard LogMessage output against exceptions

### DIFF
--- a/headers/utility/logging/logger.hpp
+++ b/headers/utility/logging/logger.hpp
@@ -144,6 +144,10 @@ namespace utility::logging
 			/**
 			 * @brief Destructor emits the accumulated message via the parent
 			 * logger.
+			 *
+			 * Output is guarded so an exception thrown by a logger
+			 * implementation cannot terminate the process, even during stack
+			 * unwinding.
 			 */
 			~LogMessage()
 			{
@@ -160,7 +164,11 @@ namespace utility::logging
 					record.line		= static_cast<int>(_location.line());
 					record.function = _location.function_name();
 				}
-				_logger->output(record);
+				try {
+					_logger->output(record);
+				} catch (...) {
+					// Logging must never become a terminate path.
+				}
 			}
 		};
 

--- a/tests/sources/logging/test_logger.cpp
+++ b/tests/sources/logging/test_logger.cpp
@@ -22,6 +22,8 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 #include "utility/logging/logger.hpp"
 #include "utility/logging/standard_logger.hpp"
 #include "utility/logging/default_logger.hpp"
@@ -154,4 +156,21 @@ TEST(StandardLoggerTest, LevelToString)
 	EXPECT_EQ(Logger::levelToString(LogLevel::INFO_LEVEL), "Info");
 	EXPECT_EQ(Logger::levelToString(LogLevel::WARNING_LEVEL), "Warning");
 	EXPECT_EQ(Logger::levelToString(LogLevel::ERROR_LEVEL), "Error");
+}
+
+TEST(LoggerTest, ThrowingOutputDoesNotTerminate)
+{
+	struct ThrowingLogger: Logger {
+		ThrowingLogger(const std::string &name)
+			: Logger(name)
+		{
+		}
+		void output(const LogRecord &) override
+		{
+			throw std::runtime_error("boom");
+		}
+	};
+
+	ThrowingLogger logger("Throw");
+	EXPECT_NO_THROW({ logger.info() << "should not terminate"; });
 }


### PR DESCRIPTION
Closes #20

Wraps the virtual output() call in ~LogMessage with a try/catch so a throwing logger implementation cannot terminate the process, including during stack unwinding. Added a test with a throwing logger.