### PR TITLE
Fix: Make logging thread-safe

### DIFF
--- a/headers/utility/logging/logger.hpp
+++ b/headers/utility/logging/logger.hpp
@@ -35,6 +35,8 @@
 
 #pragma once
 
+#include <memory>
+#include <mutex>
 #include <source_location>
 #include <sstream>
 #include <string>
@@ -80,6 +82,9 @@ namespace utility::logging
 		private:
 		std::string _name;	  ///< Logger name
 		LogLevel _minLevel = LogLevel::DEBUG_LEVEL;
+
+		protected:
+		mutable std::mutex _mutex;	  ///< Serializes output and level access
 
 		public:
 		/**
@@ -160,6 +165,7 @@ namespace utility::logging
 					record.line		= static_cast<int>(_location.line());
 					record.function = _location.function_name();
 				}
+				std::lock_guard<std::mutex> guard(_logger->_mutex);
 				_logger->output(record);
 			}
 		};

--- a/sources/logging/logger.cpp
+++ b/sources/logging/logger.cpp
@@ -21,7 +21,10 @@
  */
 
 #include <chrono>
+#include <ctime>
 #include <iomanip>
+#include <limits>
+#include <mutex>
 #include <sstream>
 
 #include "utility/logging/logger.hpp"
@@ -69,8 +72,15 @@ namespace utility::logging
 						now.time_since_epoch())
 			% 1000;
 
+		std::tm local {};
+#if defined(_WIN32)
+		localtime_s(&local, &time);
+#else
+		localtime_r(&time, &local);
+#endif
+
 		std::stringstream ss;
-		ss << std::put_time(std::localtime(&time), "%Y-%m-%d %H:%M:%S");
+		ss << std::put_time(&local, "%Y-%m-%d %H:%M:%S");
 		ss << '.' << std::setfill('0') << std::setw(3) << ms.count();
 		return ss.str();
 	}
@@ -82,11 +92,13 @@ namespace utility::logging
 
 	void Logger::setMinLevel(LogLevel level)
 	{
+		std::lock_guard<std::mutex> guard(_mutex);
 		_minLevel = level;
 	}
 
 	LogLevel Logger::getMinLevel() const
 	{
+		std::lock_guard<std::mutex> guard(_mutex);
 		return _minLevel;
 	}
 

--- a/tests/sources/logging/test_logger.cpp
+++ b/tests/sources/logging/test_logger.cpp
@@ -22,6 +22,11 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
 #include "utility/logging/logger.hpp"
 #include "utility/logging/standard_logger.hpp"
 #include "utility/logging/default_logger.hpp"
@@ -154,4 +159,36 @@ TEST(StandardLoggerTest, LevelToString)
 	EXPECT_EQ(Logger::levelToString(LogLevel::INFO_LEVEL), "Info");
 	EXPECT_EQ(Logger::levelToString(LogLevel::WARNING_LEVEL), "Warning");
 	EXPECT_EQ(Logger::levelToString(LogLevel::ERROR_LEVEL), "Error");
+}
+
+TEST(LoggerTest, ConcurrentLoggingIsSafe)
+{
+	struct CountingLogger: Logger {
+		std::atomic<int> count { 0 };
+		CountingLogger(const std::string &name)
+			: Logger(name)
+		{
+		}
+		void output(const LogRecord &) override
+		{
+			++count;
+		}
+	};
+
+	CountingLogger logger("Concurrent");
+	constexpr int kThreads	= 8;
+	constexpr int kPerThread = 500;
+
+	std::vector<std::thread> threads;
+	for (int t = 0; t < kThreads; ++t) {
+		threads.emplace_back([&]() {
+			for (int i = 0; i < kPerThread; ++i) {
+				logger.info() << "thread " << i;
+			}
+		});
+	}
+	for (auto &thread: threads) {
+		thread.join();
+	}
+	EXPECT_EQ(logger.count.load(), kThreads * kPerThread);
 }


### PR DESCRIPTION
Closes #18

Adds an internal mutex to serialize output and _minLevel access, replaces the non-thread-safe std::localtime with localtime_r/localtime_s, and adds a concurrency test that logs from 8 threads.