### PR TITLE
Feat: Add type-safe EventDispatcher

### DIFF
--- a/headers/utility/event/event_dispatcher.hpp
+++ b/headers/utility/event/event_dispatcher.hpp
@@ -1,0 +1,127 @@
+/*
+ Copyright (c) 2026 ETIB Corporation
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of
+ this software and associated documentation files (the "Software"), to deal in
+ the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do
+ so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "utility/event/event.hpp"
+
+namespace utility::event
+{
+
+	/**
+	 * @brief Dispatches typed events to registered listeners.
+	 *
+	 * Listeners are registered per concrete event type. When an event is
+	 * emitted, all listeners registered for that type are invoked with a
+	 * strongly typed reference. Events are dispatched to the concrete type
+	 * derived from the base Event pointer via a runtime type check.
+	 *
+	 * The dispatcher owns no events; it only forwards them. It is safe to
+	 * register and emit from the same thread.
+	 */
+	class EventDispatcher
+	{
+		private:
+		using Handler = std::function<void(const Event &)>;
+
+		std::unordered_map<std::size_t, std::vector<Handler>> _handlers;
+
+		template<typename EventType>
+		static std::size_t typeKey(void) noexcept
+		{
+			static const EventType *marker = nullptr;
+			return reinterpret_cast<std::size_t>(&marker);
+		}
+
+		public:
+		/**
+		 * @brief Default constructor.
+		 */
+		EventDispatcher(void) = default;
+
+		/**
+		 * @brief Default destructor.
+		 */
+		~EventDispatcher(void) = default;
+
+		/**
+		 * @brief Register a listener for a concrete event type.
+		 * @tparam EventType The concrete event type (must derive from Event).
+		 * @param listener Callable invoked with a const reference to the event.
+		 * @note The listener is invoked synchronously on the emitting thread.
+		 */
+		template<InheritFromEvent EventType, typename Callable>
+		void addListener(Callable &&listener)
+		{
+			auto key = typeKey<EventType>();
+			_handlers[key].emplace_back(
+				[fn = std::forward<Callable>(listener)](const Event &event) mutable {
+					fn(static_cast<const EventType &>(event));
+				});
+		}
+
+		/**
+		 * @brief Emit an event to all listeners registered for its concrete
+		 * type.
+		 * @tparam EventType The concrete event type.
+		 * @param event The event to dispatch.
+		 */
+		template<InheritFromEvent EventType>
+		void emit(const EventType &event) const
+		{
+			auto key = typeKey<EventType>();
+			auto it  = _handlers.find(key);
+			if (it == _handlers.end()) {
+				return;
+			}
+			for (const auto &handler: it->second) {
+				handler(event);
+			}
+		}
+
+		/**
+		 * @brief Remove all listeners registered for a concrete event type.
+		 * @tparam EventType The concrete event type.
+		 */
+		template<InheritFromEvent EventType>
+		void clearListeners(void)
+		{
+			_handlers.erase(typeKey<EventType>());
+		}
+
+		/**
+		 * @brief Remove all listeners for every event type.
+		 */
+		void clearAll(void) noexcept
+		{
+			_handlers.clear();
+		}
+	};
+
+}	 // namespace utility::event

--- a/tests/headers/event/test_event.hpp
+++ b/tests/headers/event/test_event.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+namespace tests::utility::event
+{
+	class TestEvent: public ::testing::Test
+	{
+		protected:
+		void SetUp(void) override
+		{
+		}
+		void TearDown(void) override
+		{
+		}
+	};
+}	 // namespace tests::utility::event

--- a/tests/sources/event/test_event_dispatcher.cpp
+++ b/tests/sources/event/test_event_dispatcher.cpp
@@ -1,0 +1,79 @@
+#include "event/test_event.hpp"
+
+#include "utility/event/event_dispatcher.hpp"
+#include "utility/event/mouse_motion_event.hpp"
+#include "utility/event/mouse_button_event.hpp"
+#include "utility/math/vector.hpp"
+
+using namespace utility::event;
+using namespace utility::math;
+using namespace tests::utility::event;
+
+TEST_F(TestEvent, DispatcherInvokesMatchingListener)
+{
+	EventDispatcher dispatcher;
+	MouseMotionEvent event;
+	Vector2F pos{ 3.0f, 4.0f };
+	event.setPosition(pos);
+
+	bool invoked = false;
+	Vector2F received{ 0, 0 };
+	dispatcher.addListener<MouseMotionEvent>(
+		[&](const MouseMotionEvent &e) {
+			invoked  = true;
+			received = e.getPosition();
+		});
+
+	dispatcher.emit(event);
+	EXPECT_TRUE(invoked);
+	EXPECT_EQ(received, pos);
+}
+
+TEST_F(TestEvent, DispatcherIgnoresOtherTypes)
+{
+	EventDispatcher dispatcher;
+	int count = 0;
+	dispatcher.addListener<MouseButtonEvent>(
+		[&](const MouseButtonEvent &) { ++count; });
+
+	dispatcher.emit(MouseMotionEvent{});
+	EXPECT_EQ(count, 0);
+}
+
+TEST_F(TestEvent, DispatcherSupportsMultipleListeners)
+{
+	EventDispatcher dispatcher;
+	int count = 0;
+	dispatcher.addListener<MouseMotionEvent>(
+		[&](const MouseMotionEvent &) { ++count; });
+	dispatcher.addListener<MouseMotionEvent>(
+		[&](const MouseMotionEvent &) { ++count; });
+
+	dispatcher.emit(MouseMotionEvent{});
+	EXPECT_EQ(count, 2);
+}
+
+TEST_F(TestEvent, DispatcherClearListeners)
+{
+	EventDispatcher dispatcher;
+	int count = 0;
+	dispatcher.addListener<MouseMotionEvent>(
+		[&](const MouseMotionEvent &) { ++count; });
+	dispatcher.clearListeners<MouseMotionEvent>();
+	dispatcher.emit(MouseMotionEvent{});
+	EXPECT_EQ(count, 0);
+}
+
+TEST_F(TestEvent, DispatcherClearAll)
+{
+	EventDispatcher dispatcher;
+	int count = 0;
+	dispatcher.addListener<MouseMotionEvent>(
+		[&](const MouseMotionEvent &) { ++count; });
+	dispatcher.addListener<MouseButtonEvent>(
+		[&](const MouseButtonEvent &) { ++count; });
+	dispatcher.clearAll();
+	dispatcher.emit(MouseMotionEvent{});
+	dispatcher.emit(MouseButtonEvent{});
+	EXPECT_EQ(count, 0);
+}


### PR DESCRIPTION
Closes #22

Adds EventDispatcher, a type-safe listener registration and dispatch mechanism for the event module. Listeners are registered per concrete event type and invoked with a strongly typed reference. Includes tests.