### PR TITLE
Refactor: Remove graphic::Vertex dependency from system_io

### DIFF
--- a/headers/utility/system_io/system_io.hpp
+++ b/headers/utility/system_io/system_io.hpp
@@ -32,9 +32,6 @@
 #include <vector>
 
 #include "utility/system_io/file.hpp"
-#include "utility/graphic/vertex.hpp"
-
-#include <tiny_obj_loader.h>
 
 /**
  * @namespace utility


### PR DESCRIPTION
Closes #24

Removes the unused graphic::Vertex and tiny_obj_loader includes from the system_io base header so the file/asset I/O module can be used standalone in non-rendering tools.