### PR TITLE
Refactor: Hide logging behind opaque logger in system_io

### DIFF
--- a/headers/utility/system_io/android_system_io.hpp
+++ b/headers/utility/system_io/android_system_io.hpp
@@ -27,10 +27,14 @@
 	#include <android/asset_manager.h>
 	#include <android/asset_manager_jni.h>
 
+	#include <memory>
+
 	#include "utility/system_io/system_io.hpp"
 
-	#include <utility/logging/loggable.hpp>
-	#include <utility/logging/default_logger.hpp>
+namespace utility::logging
+{
+	class Logger;
+}
 
 namespace utility
 {
@@ -40,14 +44,25 @@ namespace utility
 	 * @brief The AndroidSystemIO class is an implementation of SystemIO
 	 * that uses the Android NDK's AAssetManager to load assets from the APK.
 	 */
-	class AndroidSystemIO:
-		public SystemIO,
-		protected utility::logging::Loggable<AndroidSystemIO,
-											 utility::logging::DefaultLogger>
+	class AndroidSystemIO: public SystemIO
 	{
 		private:
 		AAssetManager
 			*_assetManager; /**< Pointer to the Android asset manager */
+		std::unique_ptr<utility::logging::Logger> _logger;
+
+		protected:
+		/**
+		 * @brief Get the internal logger.
+		 * @return Reference to the internal Logger instance.
+		 */
+		utility::logging::Logger &getLogger(void);
+
+		/**
+		 * @brief Get the internal logger.
+		 * @return Reference to the internal Logger instance.
+		 */
+		utility::logging::Logger &getLogger(void) const;
 
 		public:
 		/**
@@ -96,8 +111,6 @@ namespace utility
 		 */
 		bool save(const std::string &path,
 				  const std::string &newPath = "") override;
-
-		using Loggable::getLogger;
 	};
 }	 // namespace utility
 

--- a/headers/utility/system_io/default_system_io.hpp
+++ b/headers/utility/system_io/default_system_io.hpp
@@ -25,12 +25,15 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <string>
 
 #include "utility/system_io/system_io.hpp"
 
-#include <utility/logging/loggable.hpp>
-#include <utility/logging/default_logger.hpp>
+namespace utility::logging
+{
+	class Logger;
+}
 
 namespace utility
 {
@@ -39,26 +42,46 @@ namespace utility
 	 * @class DefaultSystemIO
 	 * @brief The DefaultSystemIO class is a concrete implementation of the
 	 * SystemIO interface that loads assets from the file system.
+	 *
+	 * Logging is kept private behind an opaque logger to avoid leaking logging
+	 * headers into the public API.
 	 */
-	class DefaultSystemIO:
-		public SystemIO,
-		protected utility::logging::Loggable<DefaultSystemIO,
-											 utility::logging::DefaultLogger>
+	class DefaultSystemIO: public SystemIO
 	{
+		private:
+		std::unique_ptr<utility::logging::Logger> _logger;
+
+		protected:
+		/**
+		 * @brief Get the internal logger.
+		 * @return Reference to the internal Logger instance.
+		 */
+		utility::logging::Logger &getLogger(void);
+
+		/**
+		 * @brief Get the internal logger.
+		 * @return Reference to the internal Logger instance.
+		 */
+		utility::logging::Logger &getLogger(void) const;
+
 		public:
 		/**
 		 * @brief Constructs a DefaultSystemIO.
 		 */
-		DefaultSystemIO() = default;
+		DefaultSystemIO();
 
-		using Loggable::getLogger;
+		/**
+		 * @brief Default destructor for DefaultSystemIO.
+		 */
+		~DefaultSystemIO() override;
+
 		using SystemIO::add;
 		using SystemIO::loadDirectory;
 		using SystemIO::remove;
 		using SystemIO::save;
 
 		/**
-		 * @brief Default destructor for DefaultSystemIO.
+		 * @brief Loads assets from a directory.
 		 * @param directory The path to the directory containing the assets.
 		 * @return True if the assets were loaded successfully, false otherwise.
 		 */

--- a/sources/system_io/android_system_io.cpp
+++ b/sources/system_io/android_system_io.cpp
@@ -26,6 +26,9 @@
 
 	#include <filesystem>
 	#include <fstream>
+	#include <memory>
+
+	#include "utility/logging/default_logger.hpp"
 
 namespace
 {
@@ -37,7 +40,18 @@ namespace
 
 utility::AndroidSystemIO::AndroidSystemIO(AAssetManager *systemInterface)
 	: _assetManager(systemInterface)
+	, _logger(std::make_unique<utility::logging::DefaultLogger>("AndroidSystemIO"))
 {
+}
+
+utility::logging::Logger &utility::AndroidSystemIO::getLogger(void)
+{
+	return *_logger;
+}
+
+utility::logging::Logger &utility::AndroidSystemIO::getLogger(void) const
+{
+	return *_logger;
 }
 
 bool utility::AndroidSystemIO::loadDirectory(const std::string &directory)

--- a/sources/system_io/default_system_io.cpp
+++ b/sources/system_io/default_system_io.cpp
@@ -21,6 +21,9 @@
  */
 
 #include <filesystem>
+#include <memory>
+
+#include "utility/logging/default_logger.hpp"
 
 #include "utility/system_io/default_system_io.hpp"
 
@@ -31,6 +34,23 @@ namespace
 		return std::filesystem::path(path).lexically_normal().generic_string();
 	}
 }	 // namespace
+
+utility::DefaultSystemIO::DefaultSystemIO()
+	: _logger(std::make_unique<utility::logging::DefaultLogger>("DefaultSystemIO"))
+{
+}
+
+utility::DefaultSystemIO::~DefaultSystemIO() = default;
+
+utility::logging::Logger &utility::DefaultSystemIO::getLogger(void)
+{
+	return *_logger;
+}
+
+utility::logging::Logger &utility::DefaultSystemIO::getLogger(void) const
+{
+	return *_logger;
+}
 
 bool utility::DefaultSystemIO::loadDirectory(const std::string &directory)
 {


### PR DESCRIPTION
Closes #25

DefaultSystemIO and AndroidSystemIO now hold a private opaque Logger instead of inheriting from Loggable, so logging headers no longer leak into the public system_io API.