### PR TITLE
Refactor: Store File content as binary bytes

### DIFF
--- a/headers/utility/system_io/file.hpp
+++ b/headers/utility/system_io/file.hpp
@@ -22,10 +22,12 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstring>
 #include <fstream>
 #include <memory>
 #include <string>
+#include <vector>
 
 /**
  * @namespace utility
@@ -39,7 +41,8 @@ namespace utility
 	 * @brief The File class represents a I/O file asset.
 	 *
 	 * This class provides methods to read and write binary data to and from a
-	 * file.
+	 * file. Content is stored as raw bytes so binary assets (which may contain
+	 * null bytes) are handled correctly.
 	 */
 	class File
 	{
@@ -62,6 +65,13 @@ namespace utility
 		 * @param content The content of the file.
 		 */
 		File(const std::string &path, const std::string &content);
+
+		/**
+		 * @brief Constructs a File object with raw binary content.
+		 * @param path The path to the file.
+		 * @param content The binary content of the file.
+		 */
+		File(const std::string &path, const std::vector<std::byte> &content);
 
 		/**
 		 * @brief Destructs the File object.
@@ -112,15 +122,26 @@ namespace utility
 		size_t tell() const;
 
 		/**
-		 * @brief Returns the content of the file.
-		 * @return The content of the file.
-		 * This method returns the content of the file as a string. The content
-		 * is stored in the _content member variable and can be accessed using
-		 * this method.
+		 * @brief Returns the binary content of the file.
+		 * @return The content of the file as raw bytes.
 		 */
-		[[nodiscard]] inline const std::string &content() const
+		[[nodiscard]] inline const std::vector<std::byte> &data() const
 		{
 			return _content;
+		}
+
+		/**
+		 * @brief Returns the content of the file as a string view.
+		 *
+		 * Convenience accessor for text-oriented consumers. For binary assets
+		 * prefer data().
+		 * @return The content of the file interpreted as bytes.
+		 */
+		[[nodiscard]] inline std::string content() const
+		{
+			return std::string(
+				reinterpret_cast<const char *>(_content.data()),
+				_content.size());
 		}
 
 		/**
@@ -174,7 +195,7 @@ namespace utility
 		/**
 		 * @brief In-memory content of the asset.
 		 */
-		std::string _content;
+		std::vector<std::byte> _content;
 
 		/**
 		 * @brief Path to the file.

--- a/sources/ressource_provider.cpp
+++ b/sources/ressource_provider.cpp
@@ -404,7 +404,7 @@ namespace utility
 		int texChannels = 0;
 
 		stbi_uc *pixels = stbi_load_from_memory(
-			reinterpret_cast<const stbi_uc *>(textureAsset->content().c_str()),
+			reinterpret_cast<const stbi_uc *>(textureAsset->data().data()),
 			textureAsset->size(), &texWidth, &texHeight, &texChannels,
 			STBI_rgb_alpha);
 

--- a/sources/sound/decoder/mp3_decoder.cpp
+++ b/sources/sound/decoder/mp3_decoder.cpp
@@ -59,7 +59,7 @@ std::shared_ptr<utility::sound::AudioBuffer>
 	DecodedAudio decodedAudio;
 	drmp3 mp3 = {};
 
-	if (drmp3_init_memory(&mp3, file->content().data(), file->size(), nullptr)
+	if (drmp3_init_memory(&mp3, file->data().data(), file->size(), nullptr)
 		== DRMP3_FALSE) {
 		// Log error but don't throw - return nullptr
 		return nullptr;

--- a/sources/sound/decoder/wav_decoder.cpp
+++ b/sources/sound/decoder/wav_decoder.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<utility::sound::AudioBuffer>
 	DecodedAudio decodedAudio;
 
 	drwav wav;
-	if (!drwav_init_memory(&wav, file->content().data(), file->size(),
+	if (!drwav_init_memory(&wav, file->data().data(), file->size(),
 						   nullptr)) {
 		// Failed to initialize the WAV decoder. Return nullptr.
 		return nullptr;

--- a/sources/system_io/android_system_io.cpp
+++ b/sources/system_io/android_system_io.cpp
@@ -127,13 +127,13 @@ bool utility::AndroidSystemIO::save(const std::string &path,
 			<< "Cannot save Android asset to original path. Provide a newPath.";
 		return false;
 	}
-	const std::string &content = it->second->content();
+	const auto &content = it->second->data();
 	std::ofstream file(newPath, std::ios::binary);
 	if (!file.is_open()) {
 		getLogger().warning() << "Failed to open file for writing: " << newPath;
 		return false;
 	}
-	file.write(content.data(), content.size());
+	file.write(reinterpret_cast<const char *>(content.data()), content.size());
 	file.close();
 	return true;
 }

--- a/sources/system_io/default_system_io.cpp
+++ b/sources/system_io/default_system_io.cpp
@@ -131,7 +131,7 @@ bool utility::DefaultSystemIO::save(const std::string &path,
 		return false;
 	}
 
-	const std::string &content = it->second->content();
+	const auto &content = it->second->data();
 	const std::string savePath = newPath.empty() ? key : newPath;
 
 	std::error_code error;
@@ -152,7 +152,7 @@ bool utility::DefaultSystemIO::save(const std::string &path,
 		return false;
 	}
 
-	file.write(content.data(), content.size());
+	file.write(reinterpret_cast<const char *>(content.data()), content.size());
 	if (!file) {
 		getLogger().warning() << "Failed to write file content: " << savePath;
 		return false;

--- a/sources/system_io/file_asset.cpp
+++ b/sources/system_io/file_asset.cpp
@@ -23,9 +23,21 @@
 #include "utility/system_io/file.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <limits>
+#include <vector>
 
 utility::File::File(const std::string &path, const std::string &content)
+	: _path(path)
+{
+	_content.reserve(content.size());
+	for (char c: content) {
+		_content.push_back(static_cast<std::byte>(c));
+	}
+}
+
+utility::File::File(const std::string &path,
+					const std::vector<std::byte> &content)
 	: _content(content)
 	, _path(path)
 {
@@ -48,13 +60,11 @@ size_t utility::File::write(const void *ptr, size_t size, size_t nmemb)
 	}
 
 	const size_t bytesToWrite = size * nmemb;
-	size_t lenBefore		  = _content.size();
-	size_t newLen			  = lenBefore + bytesToWrite;
-	if (newLen > _content.capacity()) {
-		_content.reserve(newLen);
-	}
+	const auto *bytes		   = static_cast<const std::byte *>(ptr);
+	const size_t lenBefore	   = _content.size();
 
-	_content.insert(_pos, static_cast<const char *>(ptr), bytesToWrite);
+	_content.insert(_content.begin() + static_cast<std::ptrdiff_t>(_pos),
+					bytes, bytes + bytesToWrite);
 	_pos += bytesToWrite;
 	return (_content.size() - lenBefore) / size;
 }
@@ -71,7 +81,7 @@ size_t utility::File::read(void *ptr, size_t size, size_t count)
 
 	size_t toRead = size * count;
 	toRead		  = std::min(toRead, _content.size() - _pos);
-	std::memcpy(ptr, _content.c_str() + _pos, toRead);
+	std::memcpy(ptr, _content.data() + _pos, toRead);
 	_pos += toRead;
 	return toRead / size;
 }
@@ -139,6 +149,7 @@ size_t utility::File::remove(size_t count)
 	}
 
 	size_t toRemove = std::min(count, _content.size() - _pos);
-	_content.erase(_pos, toRemove);
+	_content.erase(_content.begin() + static_cast<std::ptrdiff_t>(_pos),
+				   _content.begin() + static_cast<std::ptrdiff_t>(_pos + toRemove));
 	return toRemove;
 }

--- a/tests/headers/test_file.hpp
+++ b/tests/headers/test_file.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+namespace tests::utility
+{
+	class TestFile: public ::testing::Test
+	{
+		protected:
+		void SetUp(void) override
+		{
+		}
+		void TearDown(void) override
+		{
+		}
+	};
+}	 // namespace tests::utility

--- a/tests/sources/test_file.cpp
+++ b/tests/sources/test_file.cpp
@@ -1,0 +1,38 @@
+#include "test_file.hpp"
+
+#include <cstddef>
+
+#include "utility/system_io/file.hpp"
+
+using namespace utility;
+
+namespace tests::utility
+{
+
+	TEST_F(TestFile, StoresBinaryContent)
+	{
+		std::string content;
+		content.push_back('a');
+		content.push_back('b');
+		content.push_back('\0');
+		content.push_back('c');
+		content.push_back('d');
+		File file("/tmp/bin.dat", content);
+		EXPECT_EQ(file.size(), 5);
+		EXPECT_EQ(file.data()[2], std::byte { 0 });
+	}
+
+	TEST_F(TestFile, TextContentView)
+	{
+		File file("/tmp/asset.txt", "hello");
+		EXPECT_EQ(file.content(), "hello");
+	}
+
+	TEST_F(TestFile, DataAndTextViewAgree)
+	{
+		File file("/tmp/asset.txt", "hello");
+		EXPECT_EQ(file.content().size(), file.size());
+		EXPECT_EQ(file.content()[0], 'h');
+	}
+
+}	 // namespace tests::utility


### PR DESCRIPTION
Closes #26

File now stores content as std::vector<std::byte> via a new data() accessor, keeping a content() text view for convenience. Binary consumers (audio decoders, texture loading, save paths) use the raw bytes. Added binary-content tests.