### PR TITLE
Fix: Make Cache genuinely thread-safe

### DIFF
--- a/headers/utility/cache.hpp
+++ b/headers/utility/cache.hpp
@@ -23,7 +23,9 @@
 #pragma once
 
 #include <map>
+#include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <utility>
 #include <functional>
 #include <concepts>
@@ -69,6 +71,7 @@ namespace utility
 		std::map<Key, Entry, Compare>
 			_entries;	 ///< Internal storage for cache entries, using a
 						 ///< std::map to manage key-value pairs.
+		mutable std::shared_mutex _mutex;	///< Guards concurrent access
 
 		public:
 		/**
@@ -110,6 +113,7 @@ namespace utility
 		 */
 		bool contains(const Key &key) const
 		{
+			std::shared_lock<std::shared_mutex> guard(_mutex);
 			return _entries.find(key) != _entries.end();
 		}
 
@@ -121,6 +125,7 @@ namespace utility
 		 */
 		std::optional<Entry> get(const Key &key) const
 		{
+			std::shared_lock<std::shared_mutex> guard(_mutex);
 			auto it = _entries.find(key);
 			if (it == _entries.end()) {
 				return std::nullopt;
@@ -135,6 +140,7 @@ namespace utility
 		 */
 		void put(const Key &key, const Entry &value)
 		{
+			std::unique_lock<std::shared_mutex> guard(_mutex);
 			_entries.insert_or_assign(key, value);
 		}
 
@@ -146,6 +152,7 @@ namespace utility
 		 */
 		void put(Key &&key, Entry &&value)
 		{
+			std::unique_lock<std::shared_mutex> guard(_mutex);
 			_entries.insert_or_assign(std::move(key), std::move(value));
 		}
 
@@ -156,10 +163,14 @@ namespace utility
 		 * @param key The key to associate with the new entry.
 		 * @param args Constructor arguments for the entry.
 		 * @return Reference to the newly emplaced entry.
+		 * @note The returned reference is only valid while the calling thread
+		 * holds no other cache operation; concurrent modification may
+		 * invalidate it.
 		 */
 		template<typename... Args>
 		Entry &emplace(const Key &key, Args &&...args)
 		{
+			std::unique_lock<std::shared_mutex> guard(_mutex);
 			auto [it, inserted] =
 				_entries.try_emplace(key, std::forward<Args>(args)...);
 			return it->second;
@@ -172,9 +183,13 @@ namespace utility
 		 * @param key The key to associate with the new entry (moved).
 		 * @param args Constructor arguments for the entry.
 		 * @return Reference to the newly emplaced entry.
+		 * @note The returned reference is only valid while the calling thread
+		 * holds no other cache operation; concurrent modification may
+		 * invalidate it.
 		 */
 		template<typename... Args> Entry &emplace(Key &&key, Args &&...args)
 		{
+			std::unique_lock<std::shared_mutex> guard(_mutex);
 			auto [it, inserted] = _entries.try_emplace(
 				std::move(key), std::forward<Args>(args)...);
 			return it->second;
@@ -187,6 +202,7 @@ namespace utility
 		 */
 		bool erase(const Key &key)
 		{
+			std::unique_lock<std::shared_mutex> guard(_mutex);
 			return _entries.erase(key) > 0;
 		}
 
@@ -198,6 +214,7 @@ namespace utility
 		void erase_if(
 			const std::function<bool(const Key &, const Entry &)> &predicate)
 		{
+			std::unique_lock<std::shared_mutex> guard(_mutex);
 			for (auto it = _entries.begin(); it != _entries.end();) {
 				if (predicate(it->first, it->second)) {
 					it = _entries.erase(it);
@@ -214,6 +231,7 @@ namespace utility
 		 */
 		void apply(const std::function<void(const Key &, Entry &)> &function)
 		{
+			std::unique_lock<std::shared_mutex> guard(_mutex);
 			for (auto &[key, entry]: _entries) {
 				function(key, entry);
 			}
@@ -224,6 +242,7 @@ namespace utility
 		 */
 		void clear(void)
 		{
+			std::unique_lock<std::shared_mutex> guard(_mutex);
 			_entries.clear();
 		}
 
@@ -233,6 +252,7 @@ namespace utility
 		 */
 		std::map<Key, Entry, Compare>::size_type size(void) const
 		{
+			std::shared_lock<std::shared_mutex> guard(_mutex);
 			return _entries.size();
 		}
 
@@ -242,6 +262,7 @@ namespace utility
 		 */
 		bool empty(void) const
 		{
+			std::shared_lock<std::shared_mutex> guard(_mutex);
 			return _entries.empty();
 		}
 	};

--- a/tests/headers/test_cache.hpp
+++ b/tests/headers/test_cache.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+namespace tests::utility
+{
+	class TestCache: public ::testing::Test
+	{
+		protected:
+		void SetUp(void) override
+		{
+		}
+		void TearDown(void) override
+		{
+		}
+	};
+}	 // namespace tests::utility

--- a/tests/sources/test_cache.cpp
+++ b/tests/sources/test_cache.cpp
@@ -1,0 +1,59 @@
+#include "test_cache.hpp"
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include "utility/cache.hpp"
+
+using namespace utility;
+
+namespace tests::utility
+{
+
+	TEST_F(TestCache, ConcurrentPutAndGet)
+	{
+		Cache<int, int> cache;
+		constexpr int kThreads	= 8;
+		constexpr int kPerThread = 200;
+
+		std::vector<std::thread> writers;
+		for (int t = 0; t < kThreads; ++t) {
+			writers.emplace_back([&, t]() {
+				for (int i = 0; i < kPerThread; ++i) {
+					cache.put(t * kPerThread + i, i);
+				}
+			});
+		}
+		for (auto &thread: writers) {
+			thread.join();
+		}
+		EXPECT_EQ(cache.size(), kThreads * kPerThread);
+		EXPECT_EQ(cache.get(0), std::optional<int>(0));
+	}
+
+	TEST_F(TestCache, ConcurrentReadsDoNotCorrupt)
+	{
+		Cache<int, int> cache;
+		for (int i = 0; i < 100; ++i) {
+			cache.put(i, i);
+		}
+
+		std::atomic<int> successes { 0 };
+		std::vector<std::thread> readers;
+		for (int t = 0; t < 8; ++t) {
+			readers.emplace_back([&]() {
+				for (int i = 0; i < 100; ++i) {
+					if (cache.get(i) == std::optional<int>(i)) {
+						++successes;
+					}
+				}
+			});
+		}
+		for (auto &thread: readers) {
+			thread.join();
+		}
+		EXPECT_EQ(successes.load(), 800);
+	}
+
+}	 // namespace tests::utility


### PR DESCRIPTION
Closes #27

Cache was documented as thread-safe but had no synchronization. Added a std::shared_mutex guarding all operations (shared lock for reads, unique lock for writes) plus concurrency tests.