### PR TITLE
Fix: Make AudioManager stop flag atomic

### DIFF
--- a/headers/utility/sound/audio_manager.hpp
+++ b/headers/utility/sound/audio_manager.hpp
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <unordered_map>
 #include <thread>
@@ -289,8 +290,11 @@ namespace utility::sound
 
 		/**
 		 * @brief Indicates whether the audio thread should continue running.
+		 *
+		 * Atomic so the audio thread observes a stop() promptly without a data
+		 * race.
 		 */
-		bool _running = true;
+		std::atomic<bool> _running { true };
 
 		using Loggable::getLogger;
 	};


### PR DESCRIPTION
Closes #28

Changes the audio thread stop flag from a plain bool to std::atomic<bool> so stop() is observed promptly without a data race.