### PR TITLE
Fix: Validate View projection frustum dimensions

### DIFF
--- a/headers/utility/graphic/view.hpp
+++ b/headers/utility/graphic/view.hpp
@@ -596,6 +596,17 @@ namespace utility::graphic
 			const ViewComponentType width  = tanRight - tanLeft;
 			const ViewComponentType height = tanUp - tanDown;
 
+			if (width <= ViewComponentType { 0 }
+				|| height <= ViewComponentType { 0 }) {
+				throw std::invalid_argument(
+					"View frustum width and height must be positive");
+			}
+
+			if (_farPlane <= _nearPlane) {
+				throw std::invalid_argument(
+					"View far plane must be greater than near plane");
+			}
+
 			utility::math::Matrix<ViewComponentType, 4, 4> projection = {};
 
 			projection[0][0] = static_cast<ViewComponentType>(2) / width;

--- a/tests/sources/graphic/test_view.cpp
+++ b/tests/sources/graphic/test_view.cpp
@@ -37,6 +37,15 @@ TEST_F(TestView, ComparisonOperators)
 	EXPECT_FALSE(view1 != view2);
 }
 
+TEST_F(TestView, RejectDegenerateFrustum)
+{
+	// Symmetric zero-width/zero-height frustum yields a degenerate projection.
+	ViewF view;
+	FieldOfView<float> degenerate { 0.0f, 0.0f, 0.0f, 0.0f };
+	view.setFieldOfView(degenerate);
+	EXPECT_THROW(view.getProjectionMatrix(), std::invalid_argument);
+}
+
 TEST_F(TestView, PoseManagement)
 {
 	ViewF view;


### PR DESCRIPTION
Closes #11

getProjectionMatrix() now throws std::invalid_argument when the frustum width or height is non-positive, preventing NaN/inf for degenerate FOV angles.