### PR TITLE
Refactor: Encapsulate Texture pixel data behind accessors

### DIFF
--- a/headers/utility/graphic/texture.hpp
+++ b/headers/utility/graphic/texture.hpp
@@ -93,6 +93,27 @@ namespace utility::graphic
 		}
 
 		/**
+		 * @brief Retrieve the pixel data.
+		 * @return Read-only reference to the pixel buffer (RGBA unless this is
+		 * a FontAtlas).
+		 */
+		[[nodiscard]] const std::vector<uint8_t> &pixels() const noexcept
+		{
+			return _pixels;
+		}
+
+		/**
+		 * @brief Retrieve the pixel data for mutation.
+		 * @return Reference to the pixel buffer. Resizing it is discouraged as
+		 * it may break the width*height invariant.
+		 */
+		[[nodiscard]] std::vector<uint8_t> &pixels() noexcept
+		{
+			return _pixels;
+		}
+
+		protected:
+		/**
 		 * @brief The corresponding pixel data for this texture, stored as a
 		 * vector of bytes (RGBA format).
 		 */
@@ -103,7 +124,6 @@ namespace utility::graphic
 		 */
 		TextureType _type;
 
-		protected:
 		/**
 		 * @brief The width of the texture in pixels.
 		 */

--- a/sources/graphic/text/font_sized.cpp
+++ b/sources/graphic/text/font_sized.cpp
@@ -46,9 +46,9 @@ namespace utility::graphic
 		_generatedAtlas = std::make_shared<Texture>(
 			_atlasWidth, _atlasHeight, Texture::TextureType::FontAtlas);
 
-		_generatedAtlas->_pixels.resize(_atlasWidth * _atlasHeight, 0);
-		std::fill(_generatedAtlas->_pixels.begin(),
-				  _generatedAtlas->_pixels.end(), 0);
+		_generatedAtlas->pixels().resize(_atlasWidth * _atlasHeight, 0);
+		std::fill(_generatedAtlas->pixels().begin(),
+				  _generatedAtlas->pixels().end(), 0);
 	}
 
 	Glyph FontSized::generateGlyph(uint32_t codePoint)
@@ -110,7 +110,7 @@ namespace utility::graphic
 				const int dstY = _penY + y;
 				const int dstIndex =
 					dstY * static_cast<int>(_atlasWidth) + dstX;
-				_generatedAtlas->_pixels[dstIndex] = srcRow[x];
+				_generatedAtlas->pixels()[dstIndex] = srcRow[x];
 			}
 		}
 
@@ -157,7 +157,7 @@ namespace utility::graphic
 		if (!_generatedAtlas) {
 			_generatedAtlas = std::make_shared<Texture>(
 				_atlasWidth, _atlasHeight, Texture::TextureType::FontAtlas);
-			_generatedAtlas->_pixels.resize(_atlasWidth * _atlasHeight, 0);
+			_generatedAtlas->pixels().resize(_atlasWidth * _atlasHeight, 0);
 			shouldRegenerate = true;
 		}
 
@@ -179,8 +179,8 @@ namespace utility::graphic
 			throw std::runtime_error("Atlas texture is null");
 		}
 
-		std::fill(_generatedAtlas->_pixels.begin(),
-				  _generatedAtlas->_pixels.end(), 0);
+		std::fill(_generatedAtlas->pixels().begin(),
+				  _generatedAtlas->pixels().end(), 0);
 
 		_generatedGlyphs.clear();
 		_penX	   = 0;

--- a/sources/ressource_provider.cpp
+++ b/sources/ressource_provider.cpp
@@ -418,7 +418,7 @@ namespace utility
 
 		_textures[id] = std::make_shared<graphic::Texture>(texWidth, texHeight);
 		std::copy(pixels, pixels + (texWidth * texHeight * 4),
-				  _textures[id]->_pixels.data());
+				  _textures[id]->pixels().data());
 
 		_elementsIDs[textureAsset->path()] = id;
 		return _textures[id];


### PR DESCRIPTION
Closes #14

Moves Texture::_pixels to protected and exposes read/write pixels() accessors so external code cannot freely resize the buffer and break the width*height invariant. Updated internal call sites.