### PR TITLE
Fix: Return a copy from Material::getTextures

### DIFF
--- a/headers/utility/graphic/material.hpp
+++ b/headers/utility/graphic/material.hpp
@@ -94,15 +94,13 @@ namespace utility::graphic
 		/**
 		 * @brief Retrieves the textures associated with this material.
 		 *
-		 * This method returns a vector of pointers to Texture objects that are
-		 * associated with this material. The textures are loaded from the
-		 * File objects provided during construction and can be used for
-		 * rendering operations that require these textures.
-		 *
-		 * @return A const reference to a vector of pointers to Texture objects
+		 * This method returns a vector of shared pointers to the Texture objects
 		 * associated with this material.
+		 *
+		 * @return A vector of shared pointers to Texture objects associated with
+		 * this material.
 		 */
-		const std::vector<std::shared_ptr<Texture>> &getTextures() const;
+		std::vector<std::shared_ptr<Texture>> getTextures() const;
 
 		/**
 		 * @brief Retrieves the shader name associated with this material.

--- a/sources/graphic/material.cpp
+++ b/sources/graphic/material.cpp
@@ -39,10 +39,10 @@ namespace utility::graphic
 		return nullptr;
 	}
 
-	const std::vector<std::shared_ptr<Texture>> &Material::getTextures() const
+	std::vector<std::shared_ptr<Texture>> Material::getTextures() const
 	{
-		static std::vector<std::shared_ptr<Texture>> textures;
-		textures.clear();
+		std::vector<std::shared_ptr<Texture>> textures;
+		textures.reserve(_textures.size());
 		for (const auto &[_, texture]: _textures) {
 			textures.push_back(texture);
 		}


### PR DESCRIPTION
Closes #15

getTextures() now returns a fresh copy of the texture list instead of a reference to a shared static vector, removing the shared-state and thread-safety hazards.