### PR TITLE
Fix: Validate SPIR-V bytecode alignment in Shader

### DIFF
--- a/sources/graphic/shader.cpp
+++ b/sources/graphic/shader.cpp
@@ -5,12 +5,31 @@
 ** shader
 */
 
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
 #include <utility/graphic/shader.hpp>
 
 namespace utility::graphic
 {
+	namespace
+	{
+		void validateSpirv(const std::string &data, const char *which)
+		{
+			if (data.size() % sizeof(uint32_t) != 0) {
+				throw std::invalid_argument(
+					std::string(which)
+					+ " shader bytecode length is not a multiple of 4");
+			}
+		}
+	}	 // namespace
+
 	Shader::Shader(const std::string &vertString, const std::string &fragString)
 	{
+		validateSpirv(vertString, "Vertex");
+		validateSpirv(fragString, "Fragment");
+
 		_vertSPIRV =
 			std::vector<uint32_t>(vertString.size() / sizeof(uint32_t));
 		std::memcpy(_vertSPIRV.data(), vertString.data(), vertString.size());

--- a/tests/headers/graphic/test_shader.hpp
+++ b/tests/headers/graphic/test_shader.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+namespace tests::utility::graphic
+{
+	class TestShader: public ::testing::Test
+	{
+		protected:
+		void SetUp(void) override
+		{
+		}
+		void TearDown(void) override
+		{
+		}
+	};
+}	 // namespace tests::utility::graphic

--- a/tests/sources/graphic/test_shader.cpp
+++ b/tests/sources/graphic/test_shader.cpp
@@ -1,0 +1,35 @@
+#include "graphic/test_shader.hpp"
+
+#include <string>
+
+#include "utility/graphic/shader.hpp"
+
+using namespace utility::graphic;
+using namespace tests::utility::graphic;
+
+TEST_F(TestShader, ConstructsWithAlignedBytecode)
+{
+	// 8 bytes = 2 SPIR-V words.
+	std::string vert("\x03\x02\x23\x07\x00\x00\x00\x01", 8);
+	std::string frag("\x03\x02\x23\x07\x00\x00\x00\x02", 8);
+
+	Shader shader(vert, frag);
+	ASSERT_EQ(shader.getVertexCode().size(), 2);
+	ASSERT_EQ(shader.getFragmentCode().size(), 2);
+	EXPECT_EQ(shader.getVertexCode()[0], 0x07230203u);
+	EXPECT_EQ(shader.getFragmentCode()[0], 0x07230203u);
+}
+
+TEST_F(TestShader, RejectsMisalignedVertex)
+{
+	std::string vert("abc");	  // 3 bytes, not a multiple of 4
+	std::string frag("\x00\x00\x00\x00", 4);
+	EXPECT_THROW(Shader(vert, frag), std::invalid_argument);
+}
+
+TEST_F(TestShader, RejectsMisalignedFragment)
+{
+	std::string vert("\x00\x00\x00\x00", 4);
+	std::string frag("abcde");	  // 5 bytes, not a multiple of 4
+	EXPECT_THROW(Shader(vert, frag), std::invalid_argument);
+}


### PR DESCRIPTION
Closes #9

The Shader constructor now validates that vertex and fragment bytecode lengths are multiples of 4, throwing std::invalid_argument for misaligned input instead of silently truncating trailing bytes. Added tests.