### PR TITLE
Refactor: Hide FreeType types behind opaque handles

### DIFF
--- a/headers/utility/graphic/text/font.hpp
+++ b/headers/utility/graphic/text/font.hpp
@@ -17,9 +17,6 @@
 
 #include <utility/graphic/text/font_sized.hpp>
 
-#include <ft2build.h>
-#include FT_FREETYPE_H
-
 namespace utility::graphic
 {
 	/**
@@ -219,27 +216,19 @@ namespace utility::graphic
 		/**
 		 * @brief FreeType library instance used for managing font resources.
 		 *
-		 * This member variable holds the FreeType library instance that is
-		 * initialized when the Font object is created. It is used to load and
-		 * manage font faces, and it is cleaned up in the destructor to prevent
-		 * memory leaks.
+		 * Stored as an opaque handle to keep FreeType types out of the public
+		 * API.
 		 */
-		FT_Library _ftLibrary;
+		void *_ftLibrary;
 
 		/**
 		 * @brief Map of font paths to their corresponding FreeType face
 		 * objects.
 		 *
-		 * This map stores the loaded font faces, allowing the Font class to
-		 * manage multiple fonts and retrieve glyph information as needed. Each
-		 * entry maps a font path (as a string) to its corresponding FT_Face
-		 * object.
-		 *
-		 * The map is populated during the construction of the Font object, and
-		 * the faces are released in the destructor to ensure proper resource
-		 * management.
+		 * Faces are stored as opaque handles to keep FreeType types out of the
+		 * public API.
 		 */
-		std::map<std::string, FT_Face> _faces;
+		std::map<std::string, void *> _faces;
 
 		/**
 		 * @brief Map of font sizes to their corresponding FontSized objects.
@@ -259,8 +248,9 @@ namespace utility::graphic
 		/**
 		 * @brief In-memory buffers backing FreeType faces.
 		 *
-		 * FT_New_Memory_Face does not copy the provided bytes, so these buffers
-		 * must remain alive for as long as the corresponding FT_Face exists.
+		 * FreeType's memory-face loader does not copy the provided bytes, so
+		 * these buffers must remain alive for as long as the corresponding
+		 * face exists.
 		 */
 		std::map<std::string, std::string> _faceBuffers;
 	};

--- a/headers/utility/graphic/text/font_sized.hpp
+++ b/headers/utility/graphic/text/font_sized.hpp
@@ -12,10 +12,6 @@
 
 #include <utility/graphic/texture.hpp>
 
-// FreeType
-#include <ft2build.h>
-#include FT_FREETYPE_H
-
 // Types & structs
 #include <utility/graphic/text/code_point.hpp>
 #include <utility/graphic/text/glyph.hpp>
@@ -46,9 +42,9 @@ namespace utility::graphic
 		 *
 		 * @param fontSize The font size in points for this FontSized object.
 		 * @param face The corresponding FreeType face associated with this
-		 * FontSized object.
+		 * FontSized object (opaque handle).
 		 */
-		FontSized(uint32_t fontSize, FT_Face face);
+		FontSized(uint32_t fontSize, void *face);
 
 		/**
 		 * @brief Destructs the FontSized object, releasing any allocated
@@ -167,8 +163,11 @@ namespace utility::graphic
 		/**
 		 * @brief The corresponding FreeType face associated with this FontSized
 		 * object.
+		 *
+		 * Stored as an opaque handle to keep FreeType types out of the public
+		 * API.
 		 */
-		FT_Face _correspondingFace;
+		void *_correspondingFace;
 
 		/**
 		 * @brief A map storing the generated glyphs for this font size.

--- a/sources/graphic/text/font.cpp
+++ b/sources/graphic/text/font.cpp
@@ -7,13 +7,16 @@
 
 #include <utility/graphic/text/font.hpp>
 
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
 namespace utility::graphic
 {
 
 	Font::Font(const std::vector<File> &fontAssets)
 	{
 		// Initialize FreeType library
-		if (FT_Init_FreeType(&_ftLibrary)) {
+		if (FT_Init_FreeType(reinterpret_cast<FT_Library *>(&_ftLibrary))) {
 			throw std::runtime_error("Could not initialize FreeType library.");
 		}
 
@@ -23,7 +26,7 @@ namespace utility::graphic
 
 			FT_Face face;
 			if (FT_New_Memory_Face(
-					_ftLibrary,
+					reinterpret_cast<FT_Library>(_ftLibrary),
 					reinterpret_cast<const FT_Byte *>(buffer.data()),
 					static_cast<FT_Long>(buffer.size()), 0, &face)) {
 				throw std::runtime_error(
@@ -40,10 +43,10 @@ namespace utility::graphic
 			return;
 		}
 		for (const auto &[_, face]: _faces) {
-			FT_Done_Face(face);
+			FT_Done_Face(static_cast<FT_Face>(face));
 		}
 		if (_ftLibrary) {
-			FT_Done_FreeType(_ftLibrary);
+			FT_Done_FreeType(reinterpret_cast<FT_Library>(_ftLibrary));
 		}
 	}
 
@@ -136,7 +139,8 @@ namespace utility::graphic
 		if (_faces.empty())
 			return false;
 		for (const auto &[_, face]: _faces) {
-			if (!face || face->num_glyphs == 0) {
+			if (!face
+				|| static_cast<FT_Face>(face)->num_glyphs == 0) {
 				return false;
 			}
 		}
@@ -149,7 +153,8 @@ namespace utility::graphic
 			return false;
 		}
 		for (const auto &[_, face]: _faces) {
-			if (FT_Get_Char_Index(face, codepoint) != 0) {
+			if (FT_Get_Char_Index(static_cast<FT_Face>(face), codepoint)
+				!= 0) {
 				return true;
 			}
 		}
@@ -167,7 +172,8 @@ namespace utility::graphic
 		}
 
 		for (const auto &[faceName, face]: _faces) {
-			FT_UInt glyphIndex = FT_Get_Char_Index(face, codePoint);
+			FT_UInt glyphIndex =
+				FT_Get_Char_Index(static_cast<FT_Face>(face), codePoint);
 			if (glyphIndex != 0) {
 				return faceName;
 			}

--- a/sources/graphic/text/font_sized.cpp
+++ b/sources/graphic/text/font_sized.cpp
@@ -14,6 +14,9 @@
 #include <stdexcept>
 #include <vector>
 
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
 namespace utility::graphic
 {
 	namespace
@@ -21,7 +24,7 @@ namespace utility::graphic
 		constexpr int GLYPH_PADDING = 2;
 	}
 
-	FontSized::FontSized(uint32_t fontSize, FT_Face face)
+	FontSized::FontSized(uint32_t fontSize, void *face)
 		: _fontSize(fontSize)
 		, _correspondingFace(face)
 		, _atlasWidth(1024)
@@ -30,18 +33,18 @@ namespace utility::graphic
 		, _penY(0)
 		, _rowHeight(0)
 	{
-		if (!_correspondingFace) {
+		FT_Face ftFace = static_cast<FT_Face>(_correspondingFace);
+		if (!ftFace) {
 			throw std::runtime_error("Invalid FreeType face");
 		}
 
-		if (FT_Set_Pixel_Sizes(_correspondingFace, 0, _fontSize) != 0) {
+		if (FT_Set_Pixel_Sizes(ftFace, 0, _fontSize) != 0) {
 			throw std::runtime_error("FT_Set_Pixel_Sizes failed");
 		}
 
-		_ascender = _correspondingFace->size->metrics.ascender / 64.0f;
-		_descender =
-			std::abs(_correspondingFace->size->metrics.descender / 64.0f);
-		_lineHeight = _correspondingFace->size->metrics.height / 64.0f;
+		_ascender = ftFace->size->metrics.ascender / 64.0f;
+		_descender = std::abs(ftFace->size->metrics.descender / 64.0f);
+		_lineHeight = ftFace->size->metrics.height / 64.0f;
 
 		_generatedAtlas = std::make_shared<Texture>(
 			_atlasWidth, _atlasHeight, Texture::TextureType::FontAtlas);
@@ -58,15 +61,17 @@ namespace utility::graphic
 			return it->second;
 		}
 
-		if (FT_Set_Pixel_Sizes(_correspondingFace, 0, _fontSize) != 0) {
+		FT_Face ftFace = static_cast<FT_Face>(_correspondingFace);
+
+		if (FT_Set_Pixel_Sizes(ftFace, 0, _fontSize) != 0) {
 			throw std::runtime_error("FT_Set_Pixel_Sizes failed");
 		}
 
-		if (FT_Load_Char(_correspondingFace, codePoint, FT_LOAD_RENDER) != 0) {
+		if (FT_Load_Char(ftFace, codePoint, FT_LOAD_RENDER) != 0) {
 			throw std::runtime_error("Glyph not found");
 		}
 
-		FT_GlyphSlot g = _correspondingFace->glyph;
+		FT_GlyphSlot g = ftFace->glyph;
 		if (!g) {
 			throw std::runtime_error("Invalid glyph slot");
 		}


### PR DESCRIPTION
Closes #12

Replaces FT_Library/FT_Face in the public Font/FontSized headers with opaque void* handles. FreeType headers and casts now live only in the implementation, so consumers no longer transitively include or link FreeType.