### PR TITLE
Fix: Pin Font face buffers for stable storage

### DIFF
--- a/headers/utility/graphic/text/font.hpp
+++ b/headers/utility/graphic/text/font.hpp
@@ -12,6 +12,8 @@
 #include <memory>
 #include <functional>
 #include <iostream>
+#include <cstdint>
+#include <vector>
 
 #include <utility/system_io/file.hpp>
 
@@ -261,7 +263,9 @@ namespace utility::graphic
 		 *
 		 * FT_New_Memory_Face does not copy the provided bytes, so these buffers
 		 * must remain alive for as long as the corresponding FT_Face exists.
+		 * Buffers are heap-pinned via shared_ptr to guarantee stable storage.
 		 */
-		std::map<std::string, std::string> _faceBuffers;
+		std::map<std::string, std::shared_ptr<std::vector<uint8_t>>>
+			_faceBuffers;
 	};
 }	 // namespace utility::graphic

--- a/sources/graphic/text/font.cpp
+++ b/sources/graphic/text/font.cpp
@@ -18,14 +18,16 @@ namespace utility::graphic
 		}
 
 		for (const auto &fontAsset: fontAssets) {
-			_faceBuffers[fontAsset.path()] = fontAsset.content();
-			const auto &buffer			   = _faceBuffers.at(fontAsset.path());
+			auto buffer = std::make_shared<std::vector<uint8_t>>();
+			const std::string content = fontAsset.content();
+			buffer->assign(content.begin(), content.end());
+			_faceBuffers[fontAsset.path()] = buffer;
 
 			FT_Face face;
 			if (FT_New_Memory_Face(
 					_ftLibrary,
-					reinterpret_cast<const FT_Byte *>(buffer.data()),
-					static_cast<FT_Long>(buffer.size()), 0, &face)) {
+					reinterpret_cast<const FT_Byte *>(buffer->data()),
+					static_cast<FT_Long>(buffer->size()), 0, &face)) {
 				throw std::runtime_error(
 					"Could not load font " + fontAsset.path() + ": "
 					+ FT_Error_String(FT_Err_Cannot_Open_Resource));


### PR DESCRIPTION
Closes #30

Stores FreeType face buffers as heap-pinned std::shared_ptr<std::vector<uint8_t>> instead of std::string, guaranteeing stable storage for the lifetime of the corresponding face.