### PR TITLE
Fix: Make Text dimension query side-effect free

### DIFF
--- a/headers/utility/graphic/text/font.hpp
+++ b/headers/utility/graphic/text/font.hpp
@@ -145,6 +145,18 @@ namespace utility::graphic
 											 const codePointString &codePoints);
 
 		/**
+		 * @brief Measure the bounding size of a string of code points without
+		 * rasterizing or mutating any glyph atlas.
+		 *
+		 * This is a side-effect-free measurement based on glyph metrics.
+		 * @param fontSize The font size to measure with.
+		 * @param codePoints The code points to measure.
+		 * @return The width and height (in pixels) the text would occupy.
+		 */
+		math::Vector2F measureText(uint32_t fontSize,
+								   const codePointString &codePoints) const;
+
+		/**
 		 * @brief Retrieves the paths of the loaded font assets.
 		 *
 		 * This method returns a vector of strings containing the paths of the

--- a/headers/utility/graphic/text/font_sized.hpp
+++ b/headers/utility/graphic/text/font_sized.hpp
@@ -124,6 +124,15 @@ namespace utility::graphic
 		std::vector<Glyph> generateGlyphs(const codePointString &codePoints);
 
 		/**
+		 * @brief Compute glyph metrics for a code point without rasterizing or
+		 * mutating the texture atlas.
+		 * @param codePoint The Unicode code point to measure.
+		 * @return A Glyph whose size, bearing, and advance are populated; uv
+		 * coordinates are zero-initialized.
+		 */
+		Glyph measureGlyph(uint32_t codePoint) const;
+
+		/**
 		 * @brief The ascender value for the font size, representing the height
 		 * of the tallest glyph above the baseline.
 		 */

--- a/sources/graphic/text/font.cpp
+++ b/sources/graphic/text/font.cpp
@@ -7,6 +7,8 @@
 
 #include <utility/graphic/text/font.hpp>
 
+#include <algorithm>
+
 namespace utility::graphic
 {
 
@@ -122,9 +124,45 @@ namespace utility::graphic
 
 		return glyphs;
 	}
-	std::vector<std::string> Font::getFontPaths(void) const
+	math::Vector2F Font::measureText(uint32_t fontSize,
+									 const codePointString &codePoints) const
 	{
-		std::vector<std::string> fontPaths;
+		double width	= 0.0;
+		double maxTop	= 0.0;
+		double maxBottom = 0.0;
+
+		for (const auto &codePoint: codePoints) {
+			const std::string faceName = _getFaceNameForGlyph(codePoint);
+			if (faceName.empty()) {
+				continue;
+			}
+			const FontSizedKey key { faceName, fontSize };
+			auto fontSizedIt = _sizes.find(key);
+			if (fontSizedIt == _sizes.end()) {
+				// Not yet rasterized; measure metrics without mutating state.
+				FontSized probe(fontSize, _faces.at(faceName));
+				const Glyph metric = probe.measureGlyph(codePoint);
+				width += metric.advance;
+				maxTop	   = std::max(maxTop, static_cast<double>(metric.bearing[1]));
+				maxBottom = std::max(
+					maxBottom,
+					static_cast<double>(metric.size[1] - metric.bearing[1]));
+			} else {
+				const Glyph metric = fontSizedIt->second->measureGlyph(codePoint);
+				width += metric.advance;
+				maxTop	   = std::max(maxTop, static_cast<double>(metric.bearing[1]));
+				maxBottom = std::max(
+					maxBottom,
+					static_cast<double>(metric.size[1] - metric.bearing[1]));
+			}
+		}
+
+		return math::Vector2F { static_cast<float>(width),
+								static_cast<float>(maxTop + maxBottom) };
+	}
+
+	std::vector<std::string> Font::getFontPaths(void) const
+	{		std::vector<std::string> fontPaths;
 		for (const auto &[fontPath, _]: _faces) {
 			fontPaths.push_back(fontPath);
 		}

--- a/sources/graphic/text/font_sized.cpp
+++ b/sources/graphic/text/font_sized.cpp
@@ -152,9 +152,38 @@ namespace utility::graphic
 		return glyphs;
 	}
 
-	std::shared_ptr<Texture> FontSized::getAtlas(bool shouldRegenerate)
+	Glyph FontSized::measureGlyph(uint32_t codePoint) const
 	{
-		if (!_generatedAtlas) {
+		Glyph glyph;
+		FT_Face ftFace = static_cast<FT_Face>(_correspondingFace);
+		if (!ftFace) {
+			return glyph;
+		}
+
+		if (FT_Set_Pixel_Sizes(ftFace, 0, _fontSize) != 0) {
+			return glyph;
+		}
+
+		// Load metrics without rendering into a bitmap.
+		if (FT_Load_Char(ftFace, codePoint, FT_LOAD_NO_BITMAP) != 0) {
+			return glyph;
+		}
+
+		FT_GlyphSlot g = ftFace->glyph;
+		if (!g) {
+			return glyph;
+		}
+
+		glyph.size	 = { static_cast<float>(g->metrics.width) / 64.0f,
+						 static_cast<float>(g->metrics.height) / 64.0f };
+		glyph.bearing = { static_cast<float>(g->metrics.horiBearingX) / 64.0f,
+						  static_cast<float>(g->metrics.horiBearingY) / 64.0f };
+		glyph.advance = static_cast<float>(g->metrics.horiAdvance) / 64.0f;
+		return glyph;
+	}
+
+	std::shared_ptr<Texture> FontSized::getAtlas(bool shouldRegenerate)
+	{		if (!_generatedAtlas) {
 			_generatedAtlas = std::make_shared<Texture>(
 				_atlasWidth, _atlasHeight, Texture::TextureType::FontAtlas);
 			_generatedAtlas->_pixels.resize(_atlasWidth * _atlasHeight, 0);

--- a/sources/graphic/text/text.cpp
+++ b/sources/graphic/text/text.cpp
@@ -87,21 +87,10 @@ namespace utility::graphic
 		graphic::SizeF dimensions({ 0.0, 0.0 });
 
 		std::vector<uint32_t> codepoints = utf8ToCodepoints(_content);
-		std::vector<Glyph> glyphs =
-			_font->processCodePoints(_fontSize, codepoints);
+		const math::Vector2F measured = _font->measureText(_fontSize, codepoints);
 
-		double maxTop	 = 0.0;
-		double maxBottom = 0.0;
-
-		for (const auto &g: glyphs) {
-			dimensions.setWidth(dimensions.getWidth() + g.advance);
-			maxTop = std::max(maxTop, static_cast<double>(g.bearing[VEC_Y]));
-			maxBottom =
-				std::max(maxBottom,
-						 static_cast<double>(g.size[VEC_Y] - g.bearing[VEC_Y]));
-		}
-
-		dimensions.setHeight(maxTop + maxBottom);
+		dimensions.setWidth(measured[0]);
+		dimensions.setHeight(measured[1]);
 
 		getLogger().debug() << "Calculated text dimensions for content '"
 							<< _content << "' with font size " << _fontSize


### PR DESCRIPTION
Closes #29

Adds Font::measureText() and FontSized::measureGlyph() that compute glyph metrics without rasterizing or mutating the atlas. getTextDimensions() now uses this side-effect-free measurement path instead of processCodePoints().