### PR TITLE
Fix: Grow FontSized atlas instead of throwing when full

### DIFF
--- a/headers/utility/graphic/text/font_sized.hpp
+++ b/headers/utility/graphic/text/font_sized.hpp
@@ -155,6 +155,13 @@ namespace utility::graphic
 		void generateAtlas();
 
 		/**
+		 * @brief Grow the atlas to the given new height, preserving existing
+		 * glyphs.
+		 * @param newHeight The new atlas height in pixels.
+		 */
+		void resizeAtlas(int newHeight);
+
+		/**
 		 * @brief The font size in points for this FontSized object.
 		 */
 		std::shared_ptr<Texture> _generatedAtlas;

--- a/headers/utility/graphic/view.hpp
+++ b/headers/utility/graphic/view.hpp
@@ -67,7 +67,7 @@ namespace utility::graphic
 
 		/**
 		 * @brief Validate perspective parameter constraints.
-		 * @param verticalFovDegrees Vertical field-of-view in degrees.
+		 * @param verticalFovRadians Vertical field-of-view in radians.
 		 * @param aspectRatio Aspect ratio (width/height).
 		 * @throws std::invalid_argument if any perspective parameter is
 		 * invalid.
@@ -91,7 +91,7 @@ namespace utility::graphic
 		/**
 		 * @brief Build symmetric per-direction FOV from vertical angle and
 		 * aspect.
-		 * @param verticalFovDegrees Vertical field-of-view in degrees.
+		 * @param verticalFovRadians Vertical field-of-view in radians.
 		 * @param aspectRatio Aspect ratio (width/height).
 		 * @return Symmetric field-of-view values for all directions.
 		 */

--- a/sources/graphic/text/font_sized.cpp
+++ b/sources/graphic/text/font_sized.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <stdexcept>
@@ -88,7 +89,7 @@ namespace utility::graphic
 
 		if (_penY + glyphHeight + GLYPH_PADDING
 			>= static_cast<int>(_atlasHeight)) {
-			throw std::runtime_error("Atlas full");
+			resizeAtlas(_atlasHeight * 2);
 		}
 
 		const int pitch	   = g->bitmap.pitch;
@@ -186,5 +187,37 @@ namespace utility::graphic
 		_penX	   = 0;
 		_penY	   = 0;
 		_rowHeight = 0;
+	}
+
+	void FontSized::resizeAtlas(int newHeight)
+	{
+		if (!_generatedAtlas) {
+			_atlasHeight = newHeight;
+			return;
+		}
+
+		if (newHeight <= _atlasHeight) {
+			return;
+		}
+
+		std::vector<uint8_t> resized(
+			static_cast<size_t>(_atlasWidth) * newHeight, 0);
+
+		const int oldWidth	= static_cast<int>(_atlasWidth);
+		const int oldHeight = _atlasHeight;
+
+		for (int y = 0; y < oldHeight; ++y) {
+			const size_t srcRowStart =
+				static_cast<size_t>(y) * oldWidth;
+			const size_t dstRowStart = static_cast<size_t>(y) * oldWidth;
+			std::copy(_generatedAtlas->_pixels.begin()
+						  + static_cast<std::ptrdiff_t>(srcRowStart),
+					  _generatedAtlas->_pixels.begin()
+						  + static_cast<std::ptrdiff_t>(srcRowStart + oldWidth),
+					  resized.begin() + static_cast<std::ptrdiff_t>(dstRowStart));
+		}
+
+		_generatedAtlas->_pixels.swap(resized);
+		_atlasHeight = newHeight;
 	}
 }	 // namespace utility::graphic


### PR DESCRIPTION
Closes #13

Replaces the runtime_error on atlas-full with automatic atlas resize that doubles the height and preserves existing glyphs.